### PR TITLE
Add v0.2.1 patch plan and v0.3.0 RFC backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ This repository includes:
 - `v0.2.0-rc.3`: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/releases/RELEASE_CANDIDATE_v0.2.0-rc.3.md`
 - `v0.2.0`: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/releases/RELEASE_NOTES_v0.2.0.md`
 
+## Post-v0.2 Planning Tracks
+
+- `v0.2.1` patch-only plan: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_2_1_PATCH_PLAN.md`
+- `v0.3.0` RFC backlog (planning-only): `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_RFC_BACKLOG.md`
+
 ## v0.2 Planning Artifacts
 
 - Docs index: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/INDEX.md`

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,6 +33,8 @@ This index keeps governance, roadmap, and release artifacts discoverable while k
 - `docs/roadmap/V2_IMPLEMENTATION_CHECKLIST.md`
 - `docs/roadmap/TEST_MATRIX_v0.2.md`
 - `docs/roadmap/FAXP_DEFERRED_ITEMS.md`
+- `docs/roadmap/V0_2_1_PATCH_PLAN.md`
+- `docs/roadmap/V0_3_0_RFC_BACKLOG.md`
 
 ## Releases
 - `docs/releases/RELEASE_NOTES_v0.2.0-alpha.1.md`

--- a/docs/roadmap/V0_2_1_PATCH_PLAN.md
+++ b/docs/roadmap/V0_2_1_PATCH_PLAN.md
@@ -1,0 +1,37 @@
+# FAXP v0.2.1 Patch Plan
+
+Status: Open  
+Branch target: `codex/v0.2.1-patch`  
+Scope: Patch-only (`bugfix`, `docs correction`, `test hardening`)  
+No new protocol features in this track.
+
+## Patch Acceptance Rules
+
+1. Must fix a regression, correctness issue, security issue, or release-note/docs mismatch.
+2. Must not add new message types or expand protocol scope.
+3. Must include/adjust automated checks when behavior changes.
+4. Must pass:
+   - `./scripts/run_a2a_conformance.sh`
+   - `./scripts/run_mcp_conformance.sh`
+   - `.venv/bin/python tests/run_release_readiness.py`
+   - `.venv/bin/python conformance/run_all_checks.py`
+
+## Candidate Patch Queue
+
+1. CI/test flake hardening if any intermittent failure appears post-`v0.2.0`.
+2. Documentation consistency fixes (release notes, runbook command drift, path references).
+3. Streamlit UX safety fixes that do not alter core protocol behavior.
+4. Interop watch reliability fixes (`a2a-watch`, `mcp-watch`) if alert noise or parsing drift occurs.
+
+## Non-Goals for v0.2.1
+
+1. New protocol message types.
+2. New settlement/dispatch/tracking lifecycle behavior.
+3. A2A or MCP hard dependencies in FAXP core.
+4. Adapter-hosting architecture changes.
+
+## Exit Criteria
+
+1. Patch queue is empty or deferred to `v0.3.0`.
+2. All release gates green on patch branch.
+3. Release notes published as `RELEASE_NOTES_v0.2.1.md`.

--- a/docs/roadmap/V0_3_0_RFC_BACKLOG.md
+++ b/docs/roadmap/V0_3_0_RFC_BACKLOG.md
@@ -1,0 +1,54 @@
+# FAXP v0.3.0 RFC Backlog (Planning Only)
+
+Status: Draft backlog  
+Implementation policy: **No implementation before RFC acceptance**  
+Scope policy: Booking-plane and certification governance only.
+
+## Process
+
+1. Create RFC from `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC_TEMPLATE.md`.
+2. Classify scope gate in each RFC (`In-Scope` or `Scope Expansion`).
+3. Require security and conformance impact section.
+4. Require migration/backward-compatibility note for schema/runtime changes.
+5. Only after governance acceptance: move item into implementation checklist.
+
+## Priority Backlog
+
+1. `RFC-v0.3-rate-model-extensibility`
+- Goal: Extend booking-plane rate model taxonomy beyond `PerMile` and `Flat` while preserving backward compatibility.
+- Scope class: `In-Scope`
+- Notes: Keep accessorial lifecycle consistent with current post-booking policy semantics.
+
+2. `RFC-v0.3-shipper-orchestration-minimal`
+- Goal: Wire existing ShipperAgent stub into an optional shipper -> broker -> carrier booking path.
+- Scope class: `In-Scope`
+- Notes: Preserve current broker-carrier happy path unchanged.
+
+3. `RFC-v0.3-schema-version-negotiation`
+- Goal: Formalize version negotiation and compatibility behavior for mixed v0.2/v0.3 agents.
+- Scope class: `In-Scope`
+- Notes: No transport lock-in; conformance tests required.
+
+4. `RFC-v0.3-adapter-certification-profile-v2`
+- Goal: Advance certification profile and registry policy requirements for builder-hosted adapters.
+- Scope class: `In-Scope`
+- Notes: Keep provider neutrality and no core vendor coupling.
+
+5. `RFC-v0.3-provisional-booking-policy-contract`
+- Goal: Standardize policy semantics for `HardBlock`, `SoftHold`, and `GraceCache` outcomes.
+- Scope class: `In-Scope`
+- Notes: Keep as policy/decision contract, not dispatch-state expansion.
+
+6. `RFC-v0.3-a2a-mcp-interop-maturity`
+- Goal: Define maturity criteria for translator/tool evidence interoperability across A2A and MCP tracks.
+- Scope class: `In-Scope`
+- Notes: No mandatory A2A/MCP runtime dependency in FAXP core.
+
+## Deferred / Explicitly Out-of-Scope for v0.3.0 RFC Batch
+
+1. Dispatch operations model.
+2. Telematics/tracking lifecycle model.
+3. POD/BOL custody and document workflow standards.
+4. Invoice/payment/settlement rails.
+
+These remain scope expansions and require separate governance track beyond current protocol boundary.


### PR DESCRIPTION
## Summary
- Add v0.2.1 patch-only execution plan
- Add v0.3.0 RFC backlog (planning-only, no implementation)
- Wire both docs into README and docs index

## Scope
- Docs/planning only
- No protocol/runtime code-path changes

## Validation
- `.venv/bin/python tests/run_release_readiness.py` passed
