### PR TITLE
RFC Draft: v0.3 schema version negotiation (planning-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repository includes:
 - `v0.3.0` RFC backlog (planning-only): `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_RFC_BACKLOG.md`
 - Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 - Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-shipper-orchestration-minimal.md`
+- Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-schema-version-negotiation.md`
 
 ## v0.2 Planning Artifacts
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -22,6 +22,7 @@ This index keeps governance, roadmap, and release artifacts discoverable while k
 - `docs/rfc/RFC-v0.2-verification-neutrality.md`
 - `docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 - `docs/rfc/RFC-v0.3-shipper-orchestration-minimal.md`
+- `docs/rfc/RFC-v0.3-schema-version-negotiation.md`
 
 ## Interop
 - `docs/interop/A2A_COMPATIBILITY_PROFILE.md`

--- a/docs/rfc/RFC-v0.3-schema-version-negotiation.md
+++ b/docs/rfc/RFC-v0.3-schema-version-negotiation.md
@@ -1,0 +1,101 @@
+# RFC: v0.3 Schema Version Negotiation
+
+## RFC Metadata
+- RFC ID: `rfc-v0.3-schema-version-negotiation`
+- Title: `Define schema/version negotiation for mixed v0.2 and v0.3 agents`
+- Author(s): `FAXP Governance Working Group`
+- Status: `Draft`
+- Target Version: `v0.3.0`
+- Created: `2026-02-23`
+- Last Updated: `2026-02-23`
+
+## Summary
+Define deterministic version negotiation rules so agents with different supported schema/protocol versions can interoperate safely, fail closed when incompatible, and preserve backward compatibility across `v0.2.x` and `v0.3.x`.
+
+## Motivation
+As FAXP evolves, agents will run mixed versions in production. Without explicit negotiation rules, interop becomes ambiguous and can cause silent parsing failures or unsafe fallback behavior.
+
+## Scope Gate (Required)
+- Scope Classification: `In-Scope`
+- Protocol-Core Impacted Files:
+  - `/Users/zglitch009/projects/logistics-ai/FAXP/faxp.v0.2.schema.json`
+  - `/Users/zglitch009/projects/logistics-ai/FAXP/faxp_mvp_simulation.py`
+  - `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_schema_compatibility.py`
+- Message Types Added/Changed:
+  - No new message types required.
+  - Existing envelope metadata validation rules are clarified.
+- Schema Fields Added/Changed:
+  - Envelope compatibility/negotiation semantics for `ProtocolVersion`.
+  - Optional capability metadata for supported schema range (if adopted).
+
+### Required Checks
+- [x] This RFC stays within booking-plane protocol scope.
+- [x] No new dispatch-orchestration message or state model is introduced.
+- [x] No new tracking lifecycle model (telematics/POD/BOL custody) is introduced.
+- [x] No new settlement lifecycle model (invoice/payment/remittance/factoring) is introduced.
+- [x] If `Scope Expansion`, this RFC includes full security/compliance/interoperability/migration analysis and explicit approval request.
+
+## Detailed Design
+1. Keep `Protocol` and `ProtocolVersion` as the core compatibility anchors.
+2. Define compatibility classes:
+   - `Compatible`: message can be validated and processed without lossy behavior.
+   - `Degradable`: message can be processed with explicit downgraded semantics.
+   - `Incompatible`: message rejected fail-closed with reason code.
+3. Define default rule:
+   - Agent must process only versions explicitly declared as supported.
+   - Unknown major/minor versions fail closed unless compatibility mapping exists.
+4. Optional enhancement:
+   - Add negotiation metadata describing supported versions (range/list) during session startup or capability advertisement.
+5. Keep message contracts stable:
+   - No transport lock-in.
+   - No A2A/MCP mandatory dependency.
+
+## Security Considerations
+1. Prevent downgrade attacks by requiring explicit compatibility mapping.
+2. Reject ambiguous version values and malformed semver-like strings.
+3. Preserve signing, replay, and TTL controls during compatibility fallback.
+4. Include compatibility decision reason in audit logs.
+
+## Compliance and Governance Considerations
+1. Keep negotiation rules deterministic and test-enforced.
+2. Require migration notes for each compatibility exception.
+3. Require conformance evidence before marking a version pair as `Compatible`.
+4. Keep governance ownership over compatibility matrix updates.
+
+## Backward Compatibility
+1. `v0.2.x` agents continue to process `v0.2.x` payloads unchanged.
+2. `v0.3.x` agents must retain compatibility behavior for approved `v0.2.x` payloads.
+3. Unsupported version pairs fail closed with explicit reason code and traceable logs.
+
+## Test Plan
+1. Schema tests:
+   - version parsing/validation vectors.
+   - compatibility matrix pass/fail vectors.
+2. Integration tests:
+   - mixed-version load and truck happy-path vectors.
+3. Failure-mode tests:
+   - invalid version string.
+   - unsupported version pair.
+   - forced downgrade mismatch.
+
+## Rollout Plan
+1. RFC review and acceptance.
+2. Add formal compatibility matrix artifact.
+3. Implement parser/validator logic and compatibility reason codes.
+4. Expand schema compatibility tests and conformance suite assertions.
+5. Ship in `v0.3.0` after green CI and conformance reports.
+
+## Alternatives Considered
+1. Strict exact-version-only processing: rejected (too brittle for rollout).
+2. Implicit best-effort fallback: rejected (non-deterministic and unsafe).
+3. Out-of-band negotiation only: rejected (weak auditability in protocol flow).
+
+## Open Questions
+1. Should supported-version advertisement live in envelope extensions or capability metadata?
+2. Do we use semantic versioning strict parsing or constrained protocol version format?
+3. What is the minimum compatibility matrix retained for `v0.4.0` planning?
+
+## Approval
+- Maintainer Approval:
+- Governance Approval (if required):
+- Date:

--- a/docs/roadmap/V0_3_0_RFC_BACKLOG.md
+++ b/docs/roadmap/V0_3_0_RFC_BACKLOG.md
@@ -30,6 +30,7 @@ Scope policy: Booking-plane and certification governance only.
 - Goal: Formalize version negotiation and compatibility behavior for mixed v0.2/v0.3 agents.
 - Scope class: `In-Scope`
 - Notes: No transport lock-in; conformance tests required.
+- Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-schema-version-negotiation.md`
 
 4. `RFC-v0.3-adapter-certification-profile-v2`
 - Goal: Advance certification profile and registry policy requirements for builder-hosted adapters.


### PR DESCRIPTION
## Purpose
Planning-only RFC review for v0.3.0 schema/version negotiation.

## Included
- Draft RFC: `docs/rfc/RFC-v0.3-schema-version-negotiation.md`
- Backlog/docs links updated in:
  - `docs/roadmap/V0_3_0_RFC_BACKLOG.md`
  - `docs/INDEX.md`
  - `README.md`

## Scope
- Planning/documentation only
- No runtime/protocol implementation changes in this PR
- Booking-plane only (no dispatch/tracking/settlement expansion)

## Review Requested
1. Confirm `In-Scope` classification is correct
2. Confirm deterministic fail-closed negotiation posture
3. Confirm compatibility matrix + migration approach
4. Confirm open questions for governance decision before implementation

## Validation
- `.venv/bin/python tests/run_release_readiness.py` passed
