### PR TITLE
RFC Draft: v0.3 provisional booking policy contract (planning-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This repository includes:
 - Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-shipper-orchestration-minimal.md`
 - Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-schema-version-negotiation.md`
 - Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-adapter-certification-profile-v2.md`
+- Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md`
 
 ## v0.2 Planning Artifacts
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,6 +24,7 @@ This index keeps governance, roadmap, and release artifacts discoverable while k
 - `docs/rfc/RFC-v0.3-shipper-orchestration-minimal.md`
 - `docs/rfc/RFC-v0.3-schema-version-negotiation.md`
 - `docs/rfc/RFC-v0.3-adapter-certification-profile-v2.md`
+- `docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md`
 
 ## Interop
 - `docs/interop/A2A_COMPATIBILITY_PROFILE.md`

--- a/docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md
+++ b/docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md
@@ -1,0 +1,101 @@
+# RFC: v0.3 Provisional Booking Policy Contract
+
+## RFC Metadata
+- RFC ID: `rfc-v0.3-provisional-booking-policy-contract`
+- Title: `Standardize HardBlock, SoftHold, and GraceCache policy semantics`
+- Author(s): `FAXP Governance Working Group`
+- Status: `Draft`
+- Target Version: `v0.3.0`
+- Created: `2026-02-23`
+- Last Updated: `2026-02-23`
+
+## Summary
+Define a clear policy contract for provisional booking outcomes so verification outages and exception paths produce deterministic, auditable decisions across implementations.
+
+## Motivation
+Current behavior includes the policy concepts (`HardBlock`, `SoftHold`, `GraceCache`) but requires stronger normalization for cross-implementer consistency and certification clarity.
+
+## Scope Gate (Required)
+- Scope Classification: `In-Scope`
+- Protocol-Core Impacted Files:
+  - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/POLICY_PROFILES.md`
+  - `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_policy_decisions.py`
+  - `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_policy_profile_sync.py`
+  - `/Users/zglitch009/projects/logistics-ai/FAXP/faxp_mvp_simulation.py` (policy-decision mapping only)
+- Message Types Added/Changed:
+  - No new message types.
+  - Existing booking messages may include standardized policy decision metadata.
+- Schema Fields Added/Changed:
+  - Policy decision metadata normalization for verification outcome handling.
+  - Optional structured reason-code field alignment for provisional/blocked paths.
+
+### Required Checks
+- [x] This RFC stays within booking-plane protocol scope.
+- [x] No new dispatch-orchestration message or state model is introduced.
+- [x] No new tracking lifecycle model (telematics/POD/BOL custody) is introduced.
+- [x] No new settlement lifecycle model (invoice/payment/remittance/factoring) is introduced.
+- [x] If `Scope Expansion`, this RFC includes full security/compliance/interoperability/migration analysis and explicit approval request.
+
+## Detailed Design
+1. Normalize policy outcome categories:
+   - `HardBlock`: fail-closed, booking/dispatch blocked.
+   - `SoftHold`: provisional booking with explicit hold state pending verification.
+   - `GraceCache`: continuity decision based on risk tier and cached trusted evidence.
+2. Require explicit decision reason fields:
+   - policy profile ID
+   - decision mode
+   - reason code
+   - exception approval reference when used
+3. Define precedence order:
+   - Hard policy restrictions override discretionary exceptions unless explicitly allowed in profile.
+4. Keep policy handling in booking-plane decision logic, not dispatch lifecycle expansion.
+5. Ensure all provisional decisions are auditable and machine-checkable.
+
+## Security Considerations
+1. Prevent silent policy bypass by requiring deterministic decision path logging.
+2. Prevent replay of prior approvals by binding approvals to request scope/time.
+3. Preserve fail-closed defaults when policy metadata is missing or invalid.
+4. Enforce policy-profile integrity checks in conformance suite.
+
+## Compliance and Governance Considerations
+1. Preserve neutrality: contract defines outcomes, not vendor-specific verifiers.
+2. Require policy profile documentation and test synchronization.
+3. Require human-exception traceability fields for audit and dispute review.
+4. Ensure registry/certification profiles can declare supported policy modes.
+
+## Backward Compatibility
+1. Existing behavior remains compatible if mapped to normalized decision values.
+2. Legacy decision strings may be accepted during transition with explicit normalization.
+3. Implementers not supporting normalized fields must fail closed for ambiguous cases.
+
+## Test Plan
+1. Positive tests:
+   - expected outcomes for each policy mode across risk tiers.
+   - valid exception path with required approval reference.
+2. Negative tests:
+   - missing reason code for provisional decisions.
+   - invalid profile ID reference.
+   - stale/invalid exception approval reference.
+3. Regression:
+   - existing happy paths remain unchanged where policy is not degraded.
+
+## Rollout Plan
+1. RFC review and acceptance.
+2. Update policy profile docs and conformance checks.
+3. Implement normalized decision mapping in simulation/runtime checks.
+4. Require policy decision evidence for v0.3 certification profiles.
+
+## Alternatives Considered
+1. Leave policy semantics implementation-defined: rejected (interoperability risk).
+2. Add new protocol message types for policy events: rejected for minimal-scope phase.
+3. Collapse to single fail-open/fail-closed toggle: rejected as too coarse.
+
+## Open Questions
+1. Should exception approvals require dual-control at higher risk tiers by policy?
+2. What maximum cache age is acceptable for `GraceCache` by tier?
+3. Should policy decision metadata be required in all `ExecutionReport` outcomes or only degraded paths?
+
+## Approval
+- Maintainer Approval:
+- Governance Approval (if required):
+- Date:

--- a/docs/roadmap/V0_3_0_RFC_BACKLOG.md
+++ b/docs/roadmap/V0_3_0_RFC_BACKLOG.md
@@ -42,6 +42,7 @@ Scope policy: Booking-plane and certification governance only.
 - Goal: Standardize policy semantics for `HardBlock`, `SoftHold`, and `GraceCache` outcomes.
 - Scope class: `In-Scope`
 - Notes: Keep as policy/decision contract, not dispatch-state expansion.
+- Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md`
 
 6. `RFC-v0.3-a2a-mcp-interop-maturity`
 - Goal: Define maturity criteria for translator/tool evidence interoperability across A2A and MCP tracks.


### PR DESCRIPTION
## Purpose
Planning-only RFC review for v0.3.0 provisional booking policy contract.

## Included
- Draft RFC: `docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md`
- Backlog/docs links updated in:
  - `docs/roadmap/V0_3_0_RFC_BACKLOG.md`
  - `docs/INDEX.md`
  - `README.md`

## Scope
- Planning/documentation only
- No runtime/protocol implementation changes in this PR
- Booking-plane and governance/policy contract only

## Review Requested
1. Confirm `In-Scope` classification is correct
2. Confirm policy semantics are deterministic (`HardBlock`, `SoftHold`, `GraceCache`)
3. Confirm no dispatch/tracking/settlement expansion
4. Confirm open questions for governance decision before implementation

## Validation
- `.venv/bin/python tests/run_release_readiness.py` passed
