### PR TITLE
v0.3 governance checkpoint: must-have/deferred RFCs + commercial backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ This repository includes:
 
 - `v0.2.1` patch-only plan: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_2_1_PATCH_PLAN.md`
 - `v0.3.0` RFC backlog (planning-only): `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_RFC_BACKLOG.md`
+- `v0.3.0` governance checkpoint: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_GOVERNANCE_CHECKPOINT.md`
+- `v0.3.0` commercial model backlog: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md`
+- `v0.3.0` scenario catalog: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md`
 - Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 - Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-shipper-orchestration-minimal.md`
 - Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-schema-version-negotiation.md`

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -41,6 +41,9 @@ This index keeps governance, roadmap, and release artifacts discoverable while k
 - `docs/roadmap/FAXP_DEFERRED_ITEMS.md`
 - `docs/roadmap/V0_2_1_PATCH_PLAN.md`
 - `docs/roadmap/V0_3_0_RFC_BACKLOG.md`
+- `docs/roadmap/V0_3_0_GOVERNANCE_CHECKPOINT.md`
+- `docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md`
+- `docs/roadmap/V0_3_0_SCENARIO_CATALOG.md`
 
 ## Releases
 - `docs/releases/RELEASE_NOTES_v0.2.0-alpha.1.md`

--- a/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md
+++ b/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md
@@ -1,0 +1,118 @@
+# FAXP v0.3 Commercial Model Backlog
+
+Status: Active planning artifact  
+Purpose: Central place to capture commercial model requirements before implementation.
+
+## How to Use
+
+1. Add requirement.
+2. Assign target phase (`v0.3.0`, `v0.3.x`, or `deferred`).
+3. Link to RFC.
+4. Add acceptance criteria and compatibility notes.
+
+## Backlog Items
+
+### A) Rate Model Extensions
+
+1. `PerPallet` rate model
+- Target: `v0.3.0`
+- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- Acceptance:
+  - Negotiation supports `PerPallet`.
+  - Validation enforces pallet-count terms.
+  - Existing `PerMile`/`Flat` behavior unchanged.
+
+2. `CWT` (Hundredweight) rate model
+- Target: `v0.3.0`
+- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- Acceptance:
+  - Negotiation supports weight-unit terms.
+  - Validation enforces weight basis.
+  - Backward compatibility preserved.
+
+3. LineHaul + Fuel Surcharge componentized rates
+- Target: `v0.3.0`
+- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- Acceptance:
+  - `RateComponents` supports at least `LineHaul` and `FuelSurcharge`.
+  - Total agreed-rate can be derived deterministically.
+
+### B) Mileage Contract Terms
+
+1. Agreed miles field for `PerMile`
+- Target: `v0.3.0`
+- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- Acceptance:
+  - `AgreedMiles` captured in commercial terms.
+  - `MilesSource` and timestamp/version are auditable.
+
+2. Miles dispute/negotiation flow
+- Target: `v0.3.0`
+- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- Acceptance:
+  - Counter/reason code supports mileage disputes.
+  - Final agreed miles immutable in execution record.
+
+### C) Multi-Stop and Service Requirements
+
+1. Multi-pick / multi-drop stop model
+- Target: `v0.3.x`
+- RFC: `TBD (new RFC required)`
+- Acceptance:
+  - Ordered stop list with pickup/drop semantics.
+  - Backward-compatible single-stop default.
+
+2. Service requirements (reefer temp bands, tarping, handling constraints)
+- Target: `v0.3.x`
+- RFC: `TBD (new RFC required)`
+- Acceptance:
+  - Structured requirements object (not only free text).
+  - Validation rules by equipment/load type.
+
+3. Required delivery date / service commitment windows
+- Target: `v0.3.x`
+- RFC: `TBD (new RFC required)`
+- Acceptance:
+  - Required delivery date/time windows are structured and validated.
+  - Commitments can be negotiated with explicit acceptance/counter semantics.
+
+4. Equipment taxonomy expansion (specialty trailers + dimensional constraints)
+- Target: `v0.3.x`
+- RFC: `TBD (new RFC required)`
+- Acceptance:
+  - Trailer type vocabulary includes `Hopper`, `StepDeck`, and others.
+  - Trailer size/length is normalized and validated by equipment type.
+  - Compatibility matching handles `53' Reefer` vs `48' Reefer` correctly.
+
+5. Driver configuration requirements (single vs team) for expedited freight
+- Target: `v0.3.x`
+- RFC: `TBD (new RFC required)`
+- Acceptance:
+  - Load can declare required driver configuration.
+  - Carrier bid can declare provided configuration.
+  - Mismatch can trigger negotiation or fail-closed per policy.
+
+### D) Future Commercial Scenarios
+
+1. Additional rate structures (hourly, lane-minimums, tiered pricing)
+- Target: `deferred`
+- RFC: `TBD`
+- Acceptance:
+  - Added only via RFC with compatibility plan.
+
+2. Advanced accessorial lifecycle scenarios
+- Target: `deferred`
+- RFC: `TBD`
+- Acceptance:
+  - Clear pre-booking vs post-booking state boundaries.
+
+## Intake Template (for new items)
+
+- Requirement name:
+- Business scenario:
+- Target phase:
+- RFC link:
+- Message/schema impact:
+- Backward compatibility risk:
+- Required tests:
+- Decision owner:

--- a/docs/roadmap/V0_3_0_GOVERNANCE_CHECKPOINT.md
+++ b/docs/roadmap/V0_3_0_GOVERNANCE_CHECKPOINT.md
@@ -1,0 +1,61 @@
+# FAXP v0.3.0 Governance Checkpoint
+
+Date: 2026-02-23  
+Status: Active planning checkpoint
+
+## Decision Summary
+
+This checkpoint converts the merged v0.3 RFC drafts into an execution order with clear scope control.
+
+### Must-Have for v0.3.0
+
+1. `RFC-v0.3-rate-model-extensibility`
+- Why now: direct commercial value and adoption (supports additional rate structures like `CWT` and `PerPallet` via controlled extension model).
+- Gate: backward compatibility for `PerMile` and `Flat` remains intact.
+
+2. `RFC-v0.3-schema-version-negotiation`
+- Why now: required for safe mixed-version interop and fail-closed behavior.
+- Gate: deterministic compatibility matrix and rejection reason codes.
+
+3. `RFC-v0.3-provisional-booking-policy-contract`
+- Why now: outage/exception behavior must be deterministic and auditable.
+- Gate: normalized `HardBlock` / `SoftHold` / `GraceCache` semantics with policy evidence.
+
+### Deferred to v0.3.x (after v0.3.0)
+
+1. `RFC-v0.3-shipper-orchestration-minimal`
+- Reason: expand flow surface area only after core negotiation/policy foundations are stable.
+
+2. `RFC-v0.3-adapter-certification-profile-v2`
+- Reason: governance/certification maturity update can follow once v0.3.0 core behavior is fixed.
+
+3. `RFC-v0.3-a2a-mcp-interop-maturity`
+- Reason: current interop baseline is already operational; maturity grading can be layered afterward.
+
+## Execution Order
+
+1. Implement `schema-version-negotiation` first (safety baseline).
+2. Implement `provisional-booking-policy-contract` second (deterministic degraded behavior).
+3. Implement `rate-model-extensibility` third (commercial surface expansion).
+4. Re-run full conformance and release-readiness before tagging any v0.3.0 pre-release.
+
+## Supporting Planning Artifacts
+
+1. Commercial model backlog:
+- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md`
+2. Scenario catalog:
+- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md`
+
+## Scope Guardrails (Reconfirmed)
+
+This checkpoint does not authorize:
+1. Dispatch operations model.
+2. Telematics/tracking lifecycle model.
+3. POD/BOL custody workflow model.
+4. Invoice/payment/settlement rails.
+
+## Exit Criteria for v0.3.0 Planning Phase
+
+1. Must-have RFCs moved from `Draft` to `Review` with no unresolved scope conflicts.
+2. Implementation checklist published for the three must-have RFCs only.
+3. Deferred RFCs remain planning-only and excluded from v0.3.0 release gate.

--- a/docs/roadmap/V0_3_0_RFC_BACKLOG.md
+++ b/docs/roadmap/V0_3_0_RFC_BACKLOG.md
@@ -11,42 +11,58 @@ Scope policy: Booking-plane and certification governance only.
 3. Require security and conformance impact section.
 4. Require migration/backward-compatibility note for schema/runtime changes.
 5. Only after governance acceptance: move item into implementation checklist.
+6. Map each RFC item to at least one scenario in:
+   - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md`
+7. Track open commercial requirements in:
+   - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md`
 
 ## Priority Backlog
 
 1. `RFC-v0.3-rate-model-extensibility`
 - Goal: Extend booking-plane rate model taxonomy beyond `PerMile` and `Flat` while preserving backward compatibility.
 - Scope class: `In-Scope`
+- Status: `Draft` (Must-Have for v0.3.0)
+- Target: `v0.3.0`
 - Notes: Keep accessorial lifecycle consistent with current post-booking policy semantics.
 - Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 
 2. `RFC-v0.3-shipper-orchestration-minimal`
 - Goal: Wire existing ShipperAgent stub into an optional shipper -> broker -> carrier booking path.
 - Scope class: `In-Scope`
+- Status: `Draft` (Deferred to v0.3.x)
+- Target: `v0.3.x`
 - Notes: Preserve current broker-carrier happy path unchanged.
 - Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-shipper-orchestration-minimal.md`
 
 3. `RFC-v0.3-schema-version-negotiation`
 - Goal: Formalize version negotiation and compatibility behavior for mixed v0.2/v0.3 agents.
 - Scope class: `In-Scope`
+- Status: `Draft` (Must-Have for v0.3.0)
+- Target: `v0.3.0`
 - Notes: No transport lock-in; conformance tests required.
 - Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-schema-version-negotiation.md`
 
 4. `RFC-v0.3-adapter-certification-profile-v2`
 - Goal: Advance certification profile and registry policy requirements for builder-hosted adapters.
 - Scope class: `In-Scope`
+- Status: `Draft` (Deferred to v0.3.x)
+- Target: `v0.3.x`
 - Notes: Keep provider neutrality and no core vendor coupling.
 - Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-adapter-certification-profile-v2.md`
 
 5. `RFC-v0.3-provisional-booking-policy-contract`
 - Goal: Standardize policy semantics for `HardBlock`, `SoftHold`, and `GraceCache` outcomes.
 - Scope class: `In-Scope`
+- Status: `Draft` (Must-Have for v0.3.0)
+- Target: `v0.3.0`
 - Notes: Keep as policy/decision contract, not dispatch-state expansion.
 - Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md`
 
 6. `RFC-v0.3-a2a-mcp-interop-maturity`
 - Goal: Define maturity criteria for translator/tool evidence interoperability across A2A and MCP tracks.
 - Scope class: `In-Scope`
+- Status: `Draft` (Deferred to v0.3.x)
+- Target: `v0.3.x`
 - Notes: No mandatory A2A/MCP runtime dependency in FAXP core.
 - Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-a2a-mcp-interop-maturity.md`
 

--- a/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md
+++ b/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md
@@ -1,0 +1,127 @@
+# FAXP v0.3 Scenario Catalog
+
+Status: Active planning artifact  
+Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
+
+## Scenario Rules
+
+1. Every scenario must map to one RFC.
+2. Every scenario must define expected booking decision output.
+3. Every scenario must define backward-compatibility impact.
+
+## Scenarios
+
+### S1: PerMile with Agreed Miles
+
+- Description: Broker posts `PerMile` load with proposed miles; carrier accepts or counters miles.
+- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- Target: `v0.3.0`
+- Expected outcome:
+  - Final contract contains agreed miles and agreed rate.
+  - Dispute reason code captured when countered.
+
+### S2: PerPallet Negotiation
+
+- Description: Broker posts palletized freight with `PerPallet` pricing.
+- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- Target: `v0.3.0`
+- Expected outcome:
+  - Pallet terms validated.
+  - Execution report reflects agreed pallet-based pricing.
+
+### S3: CWT Negotiation
+
+- Description: Load priced per hundredweight (`CWT`).
+- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- Target: `v0.3.0`
+- Expected outcome:
+  - Weight basis and units validated.
+  - Execution report reflects weight-based agreed pricing.
+
+### S4: LineHaul + Fuel Surcharge Split
+
+- Description: Rate is negotiated as two components: linehaul plus FSC.
+- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- Target: `v0.3.0`
+- Expected outcome:
+  - Component values preserved.
+  - Total agreed amount derivable and auditable.
+
+### S5: Multi-Pick / Multi-Drop
+
+- Description: Load includes multiple pickups and drops.
+- RFC: `TBD (new RFC required)`
+- Target: `v0.3.x`
+- Expected outcome:
+  - Ordered stop list and constraints.
+  - Single-stop compatibility retained.
+
+### S6: Reefer Temperature Requirement
+
+- Description: Reefer load requires specific temperature range and monitoring instructions.
+- RFC: `TBD (new RFC required)`
+- Target: `v0.3.x`
+- Expected outcome:
+  - Structured temperature requirements captured.
+  - Validation enforces required fields for reefer loads.
+
+### S7: Flatbed Tarping Requirement
+
+- Description: Flatbed load requires tarping and securement notes.
+- RFC: `TBD (new RFC required)`
+- Target: `v0.3.x`
+- Expected outcome:
+  - Structured service requirement captured.
+  - Requirement appears in booking record and audit output.
+
+### S8: Verification Degraded Path with Provisional Hold
+
+- Description: Verification provider outage triggers `SoftHold` or `GraceCache` path.
+- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md`
+- Target: `v0.3.0`
+- Expected outcome:
+  - Deterministic policy decision.
+  - Explicit reason codes and exception references.
+
+### S9: Required Delivery Date Commitment
+
+- Description: Shipper/broker requires delivery by specific date/time window.
+- RFC: `TBD (new RFC required)`
+- Target: `v0.3.x`
+- Expected outcome:
+  - Delivery commitment fields are structured and validated.
+  - Carrier can accept/counter based on service window constraints.
+
+### S10: Trailer Size Match (`53'` vs `48'` Reefer)
+
+- Description: Load requires specific reefer trailer size.
+- RFC: `TBD (new RFC required)`
+- Target: `v0.3.x`
+- Expected outcome:
+  - Equipment matching distinguishes size-sensitive requirements.
+  - Incompatible size triggers no-match or negotiation path.
+
+### S11: Specialty Trailer Match (Hopper / StepDeck)
+
+- Description: Load requires non-standard trailer class.
+- RFC: `TBD (new RFC required)`
+- Target: `v0.3.x`
+- Expected outcome:
+  - Specialty equipment taxonomy is structured and validated.
+  - Matching and negotiation logic use standardized trailer classes.
+
+### S12: Expedited Team Driver Requirement
+
+- Description: Expedited shipment requires team drivers.
+- RFC: `TBD (new RFC required)`
+- Target: `v0.3.x`
+- Expected outcome:
+  - Driver configuration requirement is explicit in load terms.
+  - Carrier bid declares single/team capability.
+  - Policy handles mismatch deterministically.
+
+## Scenario Expansion Policy
+
+1. New scenario proposals must be added here first.
+2. Scenario must map to an RFC before implementation.
+3. Scenario cannot be implemented after release freeze unless classified as bugfix/security fix.


### PR DESCRIPTION
## Purpose
Planning-only governance checkpoint to prevent late-stage scope churn.

## Included
- New checkpoint: `docs/roadmap/V0_3_0_GOVERNANCE_CHECKPOINT.md`
- RFC classification updates: `docs/roadmap/V0_3_0_RFC_BACKLOG.md`
- New commercial backlog: `docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md`
- New scenario catalog: `docs/roadmap/V0_3_0_SCENARIO_CATALOG.md`
- Navigation updates: `docs/INDEX.md`, `README.md`

## Governance Decisions Captured
### Must-Have for v0.3.0
- RFC-v0.3-rate-model-extensibility
- RFC-v0.3-schema-version-negotiation
- RFC-v0.3-provisional-booking-policy-contract

### Deferred to v0.3.x
- RFC-v0.3-shipper-orchestration-minimal
- RFC-v0.3-adapter-certification-profile-v2
- RFC-v0.3-a2a-mcp-interop-maturity

## Additional commercial examples captured
- Required delivery date/service windows
- Trailer size distinctions (53' vs 48' reefer)
- Specialty trailers (hopper/stepdeck)
- Single vs team driver requirements for expedited shipments

## Scope
- Planning/documentation only
- No runtime/protocol implementation changes

## Validation
- `.venv/bin/python tests/run_release_readiness.py` passed
