### PR TITLE
feat(v0.3): practical protocol version negotiation (compatible/degradable/incompatible)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Python compile checks
         run: |
-          python -m py_compile faxp_mvp_simulation.py fmcsa_adapter_server.py streamlit_app.py streamlit_state_logic.py scripts/check_a2a_upstream.py scripts/check_mcp_upstream.py adapter/fmcsa_live.py conformance/a2a_bridge_translator.py conformance/generate_attestation.py conformance/conformance_bundle.py conformance/verifier_translator.py conformance/submission_manifest_signing.py conformance/create_submission_manifest.py conformance/registry_update_signing.py conformance/create_registry_update.py conformance/apply_registry_update.py conformance/run_all_checks.py tests/policy_profile_matrix.py tests/run_streamlit_state_logic.py tests/run_schema_compatibility.py tests/run_fmcsa_hosted_adapter.py tests/run_certification_artifacts.py tests/run_policy_decisions.py tests/run_policy_profile_sync.py tests/run_generate_attestation.py tests/run_conformance_bundle.py tests/run_verifier_translator.py tests/run_adapter_server_translation.py tests/run_adapter_test_profile.py tests/run_submission_manifest.py tests/run_create_submission_manifest.py tests/run_registry_ops_artifacts.py tests/run_registry_admission_policy.py tests/run_registry_changelog_artifacts.py tests/run_decision_record_template.py tests/run_decision_record_artifacts.py tests/run_governance_index.py tests/run_release_readiness.py tests/run_a2a_profile_check.py tests/run_a2a_roundtrip_translation.py tests/run_a2a_watch_artifacts.py tests/run_mcp_profile_check.py tests/run_mcp_watch_artifacts.py tests/run_create_registry_update.py tests/run_apply_registry_update.py tests/run_key_lifecycle_policy.py tests/run_conformance_suite.py tests/run_scope_guardrails.py
+          python -m py_compile faxp_mvp_simulation.py fmcsa_adapter_server.py streamlit_app.py streamlit_state_logic.py scripts/check_a2a_upstream.py scripts/check_mcp_upstream.py adapter/fmcsa_live.py conformance/a2a_bridge_translator.py conformance/generate_attestation.py conformance/conformance_bundle.py conformance/verifier_translator.py conformance/submission_manifest_signing.py conformance/create_submission_manifest.py conformance/registry_update_signing.py conformance/create_registry_update.py conformance/apply_registry_update.py conformance/run_all_checks.py tests/policy_profile_matrix.py tests/run_streamlit_state_logic.py tests/run_schema_compatibility.py tests/run_protocol_version_negotiation.py tests/run_fmcsa_hosted_adapter.py tests/run_certification_artifacts.py tests/run_policy_decisions.py tests/run_policy_profile_sync.py tests/run_generate_attestation.py tests/run_conformance_bundle.py tests/run_verifier_translator.py tests/run_adapter_server_translation.py tests/run_adapter_test_profile.py tests/run_submission_manifest.py tests/run_create_submission_manifest.py tests/run_registry_ops_artifacts.py tests/run_registry_admission_policy.py tests/run_registry_changelog_artifacts.py tests/run_decision_record_template.py tests/run_decision_record_artifacts.py tests/run_governance_index.py tests/run_release_readiness.py tests/run_a2a_profile_check.py tests/run_a2a_roundtrip_translation.py tests/run_a2a_watch_artifacts.py tests/run_mcp_profile_check.py tests/run_mcp_watch_artifacts.py tests/run_create_registry_update.py tests/run_apply_registry_update.py tests/run_key_lifecycle_policy.py tests/run_conformance_suite.py tests/run_scope_guardrails.py
 
       - name: Protocol scope guardrails lint
         run: |
@@ -91,6 +91,10 @@ jobs:
       - name: Schema compatibility checks (v0.1.1 + v0.2)
         run: |
           python tests/run_schema_compatibility.py
+
+      - name: Protocol version negotiation checks
+        run: |
+          python tests/run_protocol_version_negotiation.py
 
       - name: Certification/profile artifact checks
         run: |

--- a/conformance/run_all_checks.py
+++ b/conformance/run_all_checks.py
@@ -45,6 +45,7 @@ def _suite_commands() -> list[tuple[str, list[str]]]:
         ("a2a_roundtrip", [python, str(TESTS_DIR / "run_a2a_roundtrip_translation.py")]),
         ("mcp_profile", [python, str(TESTS_DIR / "run_mcp_profile_check.py")]),
         ("mcp_watch_artifacts", [python, str(TESTS_DIR / "run_mcp_watch_artifacts.py")]),
+        ("protocol_version_negotiation", [python, str(TESTS_DIR / "run_protocol_version_negotiation.py")]),
         ("registry_apply", [python, str(TESTS_DIR / "run_apply_registry_update.py")]),
         ("certification_artifacts", [python, str(TESTS_DIR / "run_certification_artifacts.py")]),
         ("policy_profile_sync", [python, str(TESTS_DIR / "run_policy_profile_sync.py")]),

--- a/faxp_mvp_simulation.py
+++ b/faxp_mvp_simulation.py
@@ -393,6 +393,18 @@ class FaxpProtocol:
 
     NAME = "FAXP"
     VERSION = "0.1.1"
+    SUPPORTED_PROTOCOL_VERSIONS = ("0.1.1", "0.2.0")
+    VERSION_COMPATIBILITY_MATRIX = {
+        # Runtime version -> incoming version -> compatibility class.
+        "0.1.1": {
+            "0.1.1": "Compatible",
+            "0.2.0": "Degradable",
+        },
+        "0.2.0": {
+            "0.2.0": "Compatible",
+            "0.1.1": "Degradable",
+        },
+    }
 
     MESSAGE_TYPES = [
         "NewLoad",
@@ -415,6 +427,92 @@ class FaxpProtocol:
             "NewRate": 2.75,
             "AmendmentNotes": "Example only for MVP visibility",
         }
+
+
+PROTOCOL_VERSION_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def negotiate_protocol_version(incoming_version, runtime_version=None):
+    """
+    Evaluate protocol-version compatibility for incoming envelopes.
+
+    Returns:
+      {
+        "status": "Compatible" | "Degradable" | "Incompatible",
+        "reasonCode": "...",
+        "incomingVersion": "...",
+        "runtimeVersion": "...",
+      }
+    """
+    runtime = str(runtime_version or FaxpProtocol.VERSION).strip()
+    incoming = str(incoming_version or "").strip()
+
+    if not runtime:
+        return {
+            "status": "Incompatible",
+            "reasonCode": "RuntimeProtocolVersionMissing",
+            "incomingVersion": incoming,
+            "runtimeVersion": runtime,
+        }
+    if not PROTOCOL_VERSION_PATTERN.fullmatch(runtime):
+        return {
+            "status": "Incompatible",
+            "reasonCode": "RuntimeProtocolVersionInvalid",
+            "incomingVersion": incoming,
+            "runtimeVersion": runtime,
+        }
+    if not incoming:
+        return {
+            "status": "Incompatible",
+            "reasonCode": "ProtocolVersionMissing",
+            "incomingVersion": incoming,
+            "runtimeVersion": runtime,
+        }
+    if not PROTOCOL_VERSION_PATTERN.fullmatch(incoming):
+        return {
+            "status": "Incompatible",
+            "reasonCode": "ProtocolVersionInvalidFormat",
+            "incomingVersion": incoming,
+            "runtimeVersion": runtime,
+        }
+
+    if incoming not in FaxpProtocol.SUPPORTED_PROTOCOL_VERSIONS:
+        return {
+            "status": "Incompatible",
+            "reasonCode": "ProtocolVersionUnsupported",
+            "incomingVersion": incoming,
+            "runtimeVersion": runtime,
+        }
+
+    matrix = FaxpProtocol.VERSION_COMPATIBILITY_MATRIX.get(runtime, {})
+    compatibility = matrix.get(incoming)
+    if compatibility in {"Compatible", "Degradable"}:
+        return {
+            "status": compatibility,
+            "reasonCode": (
+                "ProtocolVersionCompatible"
+                if compatibility == "Compatible"
+                else "ProtocolVersionDegradable"
+            ),
+            "incomingVersion": incoming,
+            "runtimeVersion": runtime,
+        }
+
+    # Fallback path for runtimes without explicit matrix entry.
+    if incoming == runtime:
+        return {
+            "status": "Compatible",
+            "reasonCode": "ProtocolVersionCompatible",
+            "incomingVersion": incoming,
+            "runtimeVersion": runtime,
+        }
+
+    return {
+        "status": "Incompatible",
+        "reasonCode": "ProtocolVersionIncompatiblePair",
+        "incomingVersion": incoming,
+        "runtimeVersion": runtime,
+    }
 
 
 def canonical_json(value):
@@ -2064,8 +2162,14 @@ def validate_envelope(envelope, track_replay=True, track_state=True):
     )
     if envelope["Protocol"] != FaxpProtocol.NAME:
         raise ValueError("Envelope.Protocol mismatch.")
-    if envelope["ProtocolVersion"] != FaxpProtocol.VERSION:
-        raise ValueError("Envelope.ProtocolVersion mismatch.")
+    version_decision = negotiate_protocol_version(envelope.get("ProtocolVersion"))
+    if version_decision["status"] == "Incompatible":
+        raise ValueError(
+            "Envelope.ProtocolVersion rejected. "
+            f"ReasonCode={version_decision['reasonCode']}. "
+            f"Incoming={version_decision['incomingVersion']!r}. "
+            f"Runtime={version_decision['runtimeVersion']!r}."
+        )
     _bounded_string(envelope["From"], "Envelope.From")
     _bounded_string(envelope["To"], "Envelope.To")
     if "RunID" in envelope:

--- a/tests/run_conformance_suite.py
+++ b/tests/run_conformance_suite.py
@@ -79,6 +79,10 @@ def main() -> int:
         "mcp_watch_artifacts" in listed_checks.stdout.splitlines(),
         "conformance suite must include mcp_watch_artifacts in default checks",
     )
+    _assert(
+        "protocol_version_negotiation" in listed_checks.stdout.splitlines(),
+        "conformance suite must include protocol_version_negotiation in default checks",
+    )
 
     with tempfile.TemporaryDirectory(prefix="faxp-conformance-suite-") as temp_dir:
         output_path = Path(temp_dir) / "suite_report.json"

--- a/tests/run_protocol_version_negotiation.py
+++ b/tests/run_protocol_version_negotiation.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Regression checks for protocol-version negotiation behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from faxp_mvp_simulation import (  # noqa: E402
+    FaxpProtocol,
+    negotiate_protocol_version,
+    now_utc,
+    validate_envelope,
+)
+
+
+def _assert(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _base_envelope(version: str) -> dict:
+    return {
+        "Protocol": "FAXP",
+        "ProtocolVersion": version,
+        "MessageType": "AmendRequest",
+        "From": "Broker Agent",
+        "To": "Carrier Agent",
+        "Timestamp": now_utc(),
+        "MessageID": str(uuid4()),
+        "Nonce": uuid4().hex,
+        "Body": {
+            "LoadID": "example-load-id",
+            "AmendmentType": "UpdateRate",
+            "ReasonCode": "MarketShift",
+        },
+    }
+
+
+def _expect_validation_error(envelope: dict, reason_code: str) -> None:
+    try:
+        validate_envelope(envelope, track_replay=False, track_state=False)
+    except ValueError as exc:
+        _assert(reason_code in str(exc), f"expected reason code {reason_code}, got: {exc}")
+        return
+    raise AssertionError(f"validation should fail with reason {reason_code}")
+
+
+def main() -> int:
+    runtime_version = FaxpProtocol.VERSION
+    runtime_decision = negotiate_protocol_version(runtime_version)
+    _assert(runtime_decision["status"] == "Compatible", "runtime version must be compatible")
+
+    # Ensure the other known version is accepted as degradable/compatible.
+    alternate_versions = [
+        version
+        for version in FaxpProtocol.SUPPORTED_PROTOCOL_VERSIONS
+        if version != runtime_version
+    ]
+    _assert(alternate_versions, "expected at least one alternate supported protocol version")
+    alternate_decision = negotiate_protocol_version(alternate_versions[0])
+    _assert(
+        alternate_decision["status"] in {"Compatible", "Degradable"},
+        "alternate supported protocol version should not be incompatible",
+    )
+    _assert(
+        alternate_decision["reasonCode"] in {"ProtocolVersionCompatible", "ProtocolVersionDegradable"},
+        "alternate version should produce compatible/degradable reason code",
+    )
+
+    # Envelope validation accepts current and alternate supported versions.
+    validate_envelope(_base_envelope(runtime_version), track_replay=False, track_state=False)
+    validate_envelope(
+        _base_envelope(alternate_versions[0]),
+        track_replay=False,
+        track_state=False,
+    )
+
+    unsupported_decision = negotiate_protocol_version("9.9.9")
+    _assert(
+        unsupported_decision["status"] == "Incompatible"
+        and unsupported_decision["reasonCode"] == "ProtocolVersionUnsupported",
+        "unsupported version should be rejected with ProtocolVersionUnsupported",
+    )
+    _expect_validation_error(_base_envelope("9.9.9"), "ProtocolVersionUnsupported")
+
+    invalid_format_decision = negotiate_protocol_version("v0.3")
+    _assert(
+        invalid_format_decision["status"] == "Incompatible"
+        and invalid_format_decision["reasonCode"] == "ProtocolVersionInvalidFormat",
+        "invalid format should be rejected with ProtocolVersionInvalidFormat",
+    )
+    _expect_validation_error(_base_envelope("v0.3"), "ProtocolVersionInvalidFormat")
+
+    missing_decision = negotiate_protocol_version("")
+    _assert(
+        missing_decision["status"] == "Incompatible"
+        and missing_decision["reasonCode"] == "ProtocolVersionMissing",
+        "missing version should be rejected with ProtocolVersionMissing",
+    )
+    _expect_validation_error(_base_envelope(""), "ProtocolVersionMissing")
+
+    bad_runtime_decision = negotiate_protocol_version(runtime_version, runtime_version="broken")
+    _assert(
+        bad_runtime_decision["status"] == "Incompatible"
+        and bad_runtime_decision["reasonCode"] == "RuntimeProtocolVersionInvalid",
+        "invalid runtime version should produce RuntimeProtocolVersionInvalid",
+    )
+
+    print("Protocol version negotiation checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Implements practical protocol version negotiation for FAXP with explicit compatibility outcomes and fail-closed validation.

## Changes
- Added negotiation model in `faxp_mvp_simulation.py`:
  - Supported versions list and compatibility matrix
  - `negotiate_protocol_version(...)`
  - Explicit reason codes for compatibility decisions
- Updated envelope validation to:
  - Allow `Compatible` and `Degradable`
  - Reject `Incompatible` with clear reason code
- Added new test:
  - `tests/run_protocol_version_negotiation.py`
- Added conformance + CI coverage for new test.

## Validation
- `./.venv/bin/python tests/run_protocol_version_negotiation.py`
- `./.venv/bin/python tests/run_conformance_suite.py`
- `./.venv/bin/python tests/run_release_readiness.py`

## Notes
- Intentionally staged only protocol-version work.
- Left unrelated untracked files (`A2A`, `FAXP`) untouched.
