### PR TITLE
test(v0.3): fixture-based cross-version protocol conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Python compile checks
         run: |
-          python -m py_compile faxp_mvp_simulation.py fmcsa_adapter_server.py streamlit_app.py streamlit_state_logic.py scripts/check_a2a_upstream.py scripts/check_mcp_upstream.py adapter/fmcsa_live.py conformance/a2a_bridge_translator.py conformance/generate_attestation.py conformance/conformance_bundle.py conformance/verifier_translator.py conformance/submission_manifest_signing.py conformance/create_submission_manifest.py conformance/registry_update_signing.py conformance/create_registry_update.py conformance/apply_registry_update.py conformance/run_all_checks.py tests/policy_profile_matrix.py tests/run_streamlit_state_logic.py tests/run_schema_compatibility.py tests/run_protocol_version_negotiation.py tests/run_fmcsa_hosted_adapter.py tests/run_certification_artifacts.py tests/run_policy_decisions.py tests/run_policy_profile_sync.py tests/run_generate_attestation.py tests/run_conformance_bundle.py tests/run_verifier_translator.py tests/run_adapter_server_translation.py tests/run_adapter_test_profile.py tests/run_submission_manifest.py tests/run_create_submission_manifest.py tests/run_registry_ops_artifacts.py tests/run_registry_admission_policy.py tests/run_registry_changelog_artifacts.py tests/run_decision_record_template.py tests/run_decision_record_artifacts.py tests/run_governance_index.py tests/run_release_readiness.py tests/run_a2a_profile_check.py tests/run_a2a_roundtrip_translation.py tests/run_a2a_watch_artifacts.py tests/run_mcp_profile_check.py tests/run_mcp_watch_artifacts.py tests/run_create_registry_update.py tests/run_apply_registry_update.py tests/run_key_lifecycle_policy.py tests/run_conformance_suite.py tests/run_scope_guardrails.py
+          python -m py_compile faxp_mvp_simulation.py fmcsa_adapter_server.py streamlit_app.py streamlit_state_logic.py scripts/check_a2a_upstream.py scripts/check_mcp_upstream.py adapter/fmcsa_live.py conformance/a2a_bridge_translator.py conformance/generate_attestation.py conformance/conformance_bundle.py conformance/verifier_translator.py conformance/submission_manifest_signing.py conformance/create_submission_manifest.py conformance/registry_update_signing.py conformance/create_registry_update.py conformance/apply_registry_update.py conformance/run_all_checks.py tests/policy_profile_matrix.py tests/run_streamlit_state_logic.py tests/run_schema_compatibility.py tests/run_protocol_version_negotiation.py tests/run_cross_version_fixtures.py tests/run_fmcsa_hosted_adapter.py tests/run_certification_artifacts.py tests/run_policy_decisions.py tests/run_policy_profile_sync.py tests/run_generate_attestation.py tests/run_conformance_bundle.py tests/run_verifier_translator.py tests/run_adapter_server_translation.py tests/run_adapter_test_profile.py tests/run_submission_manifest.py tests/run_create_submission_manifest.py tests/run_registry_ops_artifacts.py tests/run_registry_admission_policy.py tests/run_registry_changelog_artifacts.py tests/run_decision_record_template.py tests/run_decision_record_artifacts.py tests/run_governance_index.py tests/run_release_readiness.py tests/run_a2a_profile_check.py tests/run_a2a_roundtrip_translation.py tests/run_a2a_watch_artifacts.py tests/run_mcp_profile_check.py tests/run_mcp_watch_artifacts.py tests/run_create_registry_update.py tests/run_apply_registry_update.py tests/run_key_lifecycle_policy.py tests/run_conformance_suite.py tests/run_scope_guardrails.py
 
       - name: Protocol scope guardrails lint
         run: |
@@ -95,6 +95,10 @@ jobs:
       - name: Protocol version negotiation checks
         run: |
           python tests/run_protocol_version_negotiation.py
+
+      - name: Cross-version fixture conformance checks
+        run: |
+          python tests/run_cross_version_fixtures.py
 
       - name: Certification/profile artifact checks
         run: |

--- a/conformance/run_all_checks.py
+++ b/conformance/run_all_checks.py
@@ -46,6 +46,7 @@ def _suite_commands() -> list[tuple[str, list[str]]]:
         ("mcp_profile", [python, str(TESTS_DIR / "run_mcp_profile_check.py")]),
         ("mcp_watch_artifacts", [python, str(TESTS_DIR / "run_mcp_watch_artifacts.py")]),
         ("protocol_version_negotiation", [python, str(TESTS_DIR / "run_protocol_version_negotiation.py")]),
+        ("cross_version_fixtures", [python, str(TESTS_DIR / "run_cross_version_fixtures.py")]),
         ("registry_apply", [python, str(TESTS_DIR / "run_apply_registry_update.py")]),
         ("certification_artifacts", [python, str(TESTS_DIR / "run_certification_artifacts.py")]),
         ("policy_profile_sync", [python, str(TESTS_DIR / "run_policy_profile_sync.py")]),

--- a/tests/protocol_version_fixtures.json
+++ b/tests/protocol_version_fixtures.json
@@ -1,0 +1,54 @@
+{
+  "fixtures": [
+    {
+      "id": "runtime-0.1.1-incoming-0.1.1-compatible",
+      "runtimeVersion": "0.1.1",
+      "incomingVersion": "0.1.1",
+      "expectedStatus": "Compatible",
+      "expectedReasonCode": "ProtocolVersionCompatible",
+      "expectEnvelopeValidationPass": true
+    },
+    {
+      "id": "runtime-0.1.1-incoming-0.2.0-degradable",
+      "runtimeVersion": "0.1.1",
+      "incomingVersion": "0.2.0",
+      "expectedStatus": "Degradable",
+      "expectedReasonCode": "ProtocolVersionDegradable",
+      "expectEnvelopeValidationPass": true
+    },
+    {
+      "id": "runtime-0.2.0-incoming-0.2.0-compatible",
+      "runtimeVersion": "0.2.0",
+      "incomingVersion": "0.2.0",
+      "expectedStatus": "Compatible",
+      "expectedReasonCode": "ProtocolVersionCompatible",
+      "expectEnvelopeValidationPass": true
+    },
+    {
+      "id": "runtime-0.2.0-incoming-0.1.1-degradable",
+      "runtimeVersion": "0.2.0",
+      "incomingVersion": "0.1.1",
+      "expectedStatus": "Degradable",
+      "expectedReasonCode": "ProtocolVersionDegradable",
+      "expectEnvelopeValidationPass": true
+    },
+    {
+      "id": "runtime-0.1.1-incoming-9.9.9-unsupported",
+      "runtimeVersion": "0.1.1",
+      "incomingVersion": "9.9.9",
+      "expectedStatus": "Incompatible",
+      "expectedReasonCode": "ProtocolVersionUnsupported",
+      "expectEnvelopeValidationPass": false,
+      "expectedValidationReasonCode": "ProtocolVersionUnsupported"
+    },
+    {
+      "id": "runtime-0.1.1-incoming-v0.3-invalid-format",
+      "runtimeVersion": "0.1.1",
+      "incomingVersion": "v0.3",
+      "expectedStatus": "Incompatible",
+      "expectedReasonCode": "ProtocolVersionInvalidFormat",
+      "expectEnvelopeValidationPass": false,
+      "expectedValidationReasonCode": "ProtocolVersionInvalidFormat"
+    }
+  ]
+}

--- a/tests/run_conformance_suite.py
+++ b/tests/run_conformance_suite.py
@@ -83,6 +83,10 @@ def main() -> int:
         "protocol_version_negotiation" in listed_checks.stdout.splitlines(),
         "conformance suite must include protocol_version_negotiation in default checks",
     )
+    _assert(
+        "cross_version_fixtures" in listed_checks.stdout.splitlines(),
+        "conformance suite must include cross_version_fixtures in default checks",
+    )
 
     with tempfile.TemporaryDirectory(prefix="faxp-conformance-suite-") as temp_dir:
         output_path = Path(temp_dir) / "suite_report.json"

--- a/tests/run_cross_version_fixtures.py
+++ b/tests/run_cross_version_fixtures.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Fixture-based protocol-version conformance checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+import json
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from faxp_mvp_simulation import (  # noqa: E402
+    FaxpProtocol,
+    negotiate_protocol_version,
+    now_utc,
+    validate_envelope,
+)
+
+
+FIXTURES_PATH = PROJECT_ROOT / "tests" / "protocol_version_fixtures.json"
+
+
+def _assert(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _load_fixtures() -> list[dict]:
+    with FIXTURES_PATH.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    fixtures = payload.get("fixtures")
+    _assert(isinstance(fixtures, list) and fixtures, "Fixture list must be non-empty.")
+    return fixtures
+
+
+def _build_envelope(version: str) -> dict:
+    return {
+        "Protocol": "FAXP",
+        "ProtocolVersion": version,
+        "MessageType": "AmendRequest",
+        "From": "Broker Agent",
+        "To": "Carrier Agent",
+        "Timestamp": now_utc(),
+        "MessageID": str(uuid4()),
+        "Nonce": uuid4().hex,
+        "Body": {
+            "LoadID": "fixture-load-id",
+            "AmendmentType": "UpdateRate",
+            "ReasonCode": "MarketShift",
+        },
+    }
+
+
+def _validate_fixture_envelope(
+    fixture_id: str,
+    runtime_version: str,
+    incoming_version: str,
+    expect_pass: bool,
+    expected_validation_reason: str,
+) -> None:
+    original_runtime = FaxpProtocol.VERSION
+    try:
+        FaxpProtocol.VERSION = runtime_version
+        envelope = _build_envelope(incoming_version)
+        if expect_pass:
+            validate_envelope(envelope, track_replay=False, track_state=False)
+            return
+        try:
+            validate_envelope(envelope, track_replay=False, track_state=False)
+        except ValueError as exc:
+            _assert(
+                expected_validation_reason in str(exc),
+                f"{fixture_id}: expected validation reason {expected_validation_reason}, got: {exc}",
+            )
+            return
+        raise AssertionError(f"{fixture_id}: expected validation failure but got success")
+    finally:
+        FaxpProtocol.VERSION = original_runtime
+
+
+def main() -> int:
+    fixtures = _load_fixtures()
+    for fixture in fixtures:
+        fixture_id = str(fixture.get("id") or "").strip()
+        _assert(fixture_id, "each fixture requires a non-empty id")
+
+        runtime_version = str(fixture.get("runtimeVersion") or "").strip()
+        incoming_version = str(fixture.get("incomingVersion") or "").strip()
+        expected_status = str(fixture.get("expectedStatus") or "").strip()
+        expected_reason = str(fixture.get("expectedReasonCode") or "").strip()
+
+        _assert(runtime_version, f"{fixture_id}: runtimeVersion is required")
+        _assert(incoming_version, f"{fixture_id}: incomingVersion is required")
+        _assert(expected_status, f"{fixture_id}: expectedStatus is required")
+        _assert(expected_reason, f"{fixture_id}: expectedReasonCode is required")
+
+        decision = negotiate_protocol_version(incoming_version, runtime_version=runtime_version)
+        _assert(
+            decision.get("status") == expected_status,
+            (
+                f"{fixture_id}: expected status {expected_status}, "
+                f"got {decision.get('status')}"
+            ),
+        )
+        _assert(
+            decision.get("reasonCode") == expected_reason,
+            (
+                f"{fixture_id}: expected reasonCode {expected_reason}, "
+                f"got {decision.get('reasonCode')}"
+            ),
+        )
+        _assert(
+            decision.get("incomingVersion") == incoming_version,
+            f"{fixture_id}: incomingVersion mismatch in decision payload",
+        )
+        _assert(
+            decision.get("runtimeVersion") == runtime_version,
+            f"{fixture_id}: runtimeVersion mismatch in decision payload",
+        )
+
+        expect_validation_pass = bool(fixture.get("expectEnvelopeValidationPass", False))
+        expected_validation_reason = str(
+            fixture.get("expectedValidationReasonCode") or expected_reason
+        ).strip()
+
+        _validate_fixture_envelope(
+            fixture_id=fixture_id,
+            runtime_version=runtime_version,
+            incoming_version=incoming_version,
+            expect_pass=expect_validation_pass,
+            expected_validation_reason=expected_validation_reason,
+        )
+
+    print("Cross-version fixture conformance checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds fixture-based cross-version conformance coverage for FAXP protocol-version negotiation and envelope validation behavior.

## What changed
- Added version fixture pack:
  - `tests/protocol_version_fixtures.json`
- Added new regression test:
  - `tests/run_cross_version_fixtures.py`
- Wired new check into default conformance suite:
  - `conformance/run_all_checks.py` (`cross_version_fixtures`)
- Updated conformance orchestrator regression expectations:
  - `tests/run_conformance_suite.py`
- Added CI coverage:
  - py_compile includes `tests/run_cross_version_fixtures.py`
  - new CI step runs `python tests/run_cross_version_fixtures.py`

## Coverage goals
The fixture set explicitly verifies:
- `0.1.1 -> 0.1.1` = `Compatible`
- `0.1.1 -> 0.2.0` = `Degradable`
- `0.2.0 -> 0.2.0` = `Compatible`
- `0.2.0 -> 0.1.1` = `Degradable`
- unsupported/invalid versions fail closed with explicit reason codes.

## Validation run
- `./.venv/bin/python tests/run_cross_version_fixtures.py`
- `./.venv/bin/python tests/run_protocol_version_negotiation.py`
- `./.venv/bin/python tests/run_conformance_suite.py`
- `./.venv/bin/python tests/run_release_readiness.py`
- `./.venv/bin/python conformance/run_all_checks.py --checks cross_version_fixtures --output /tmp/faxp_conformance_suite_report.cross_version.json`

## Notes
- Staged only cross-version fixture work.
- Left unrelated untracked local files untouched.
