### PR TITLE
feat(v0.3): enforce protocol compatibility profile in conformance + governance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Python compile checks
         run: |
-          python -m py_compile faxp_mvp_simulation.py fmcsa_adapter_server.py streamlit_app.py streamlit_state_logic.py scripts/check_a2a_upstream.py scripts/check_mcp_upstream.py adapter/fmcsa_live.py conformance/a2a_bridge_translator.py conformance/generate_attestation.py conformance/conformance_bundle.py conformance/verifier_translator.py conformance/submission_manifest_signing.py conformance/create_submission_manifest.py conformance/registry_update_signing.py conformance/create_registry_update.py conformance/apply_registry_update.py conformance/run_all_checks.py tests/policy_profile_matrix.py tests/run_streamlit_state_logic.py tests/run_schema_compatibility.py tests/run_protocol_version_negotiation.py tests/run_cross_version_fixtures.py tests/run_fmcsa_hosted_adapter.py tests/run_certification_artifacts.py tests/run_policy_decisions.py tests/run_policy_profile_sync.py tests/run_generate_attestation.py tests/run_conformance_bundle.py tests/run_verifier_translator.py tests/run_adapter_server_translation.py tests/run_adapter_test_profile.py tests/run_submission_manifest.py tests/run_create_submission_manifest.py tests/run_registry_ops_artifacts.py tests/run_registry_admission_policy.py tests/run_registry_changelog_artifacts.py tests/run_decision_record_template.py tests/run_decision_record_artifacts.py tests/run_governance_index.py tests/run_release_readiness.py tests/run_a2a_profile_check.py tests/run_a2a_roundtrip_translation.py tests/run_a2a_watch_artifacts.py tests/run_mcp_profile_check.py tests/run_mcp_watch_artifacts.py tests/run_create_registry_update.py tests/run_apply_registry_update.py tests/run_key_lifecycle_policy.py tests/run_conformance_suite.py tests/run_scope_guardrails.py
+          python -m py_compile faxp_mvp_simulation.py fmcsa_adapter_server.py streamlit_app.py streamlit_state_logic.py scripts/check_a2a_upstream.py scripts/check_mcp_upstream.py adapter/fmcsa_live.py conformance/a2a_bridge_translator.py conformance/generate_attestation.py conformance/conformance_bundle.py conformance/verifier_translator.py conformance/submission_manifest_signing.py conformance/create_submission_manifest.py conformance/registry_update_signing.py conformance/create_registry_update.py conformance/apply_registry_update.py conformance/run_all_checks.py tests/policy_profile_matrix.py tests/run_streamlit_state_logic.py tests/run_schema_compatibility.py tests/run_protocol_compatibility_profile.py tests/run_protocol_version_negotiation.py tests/run_cross_version_fixtures.py tests/run_fmcsa_hosted_adapter.py tests/run_certification_artifacts.py tests/run_policy_decisions.py tests/run_policy_profile_sync.py tests/run_generate_attestation.py tests/run_conformance_bundle.py tests/run_verifier_translator.py tests/run_adapter_server_translation.py tests/run_adapter_test_profile.py tests/run_submission_manifest.py tests/run_create_submission_manifest.py tests/run_registry_ops_artifacts.py tests/run_registry_admission_policy.py tests/run_registry_changelog_artifacts.py tests/run_decision_record_template.py tests/run_decision_record_artifacts.py tests/run_governance_index.py tests/run_release_readiness.py tests/run_a2a_profile_check.py tests/run_a2a_roundtrip_translation.py tests/run_a2a_watch_artifacts.py tests/run_mcp_profile_check.py tests/run_mcp_watch_artifacts.py tests/run_create_registry_update.py tests/run_apply_registry_update.py tests/run_key_lifecycle_policy.py tests/run_conformance_suite.py tests/run_scope_guardrails.py
 
       - name: Protocol scope guardrails lint
         run: |
@@ -95,6 +95,10 @@ jobs:
       - name: Protocol version negotiation checks
         run: |
           python tests/run_protocol_version_negotiation.py
+
+      - name: Protocol compatibility profile checks
+        run: |
+          python tests/run_protocol_compatibility_profile.py
 
       - name: Cross-version fixture conformance checks
         run: |

--- a/conformance/protocol_compatibility_profile.v1.json
+++ b/conformance/protocol_compatibility_profile.v1.json
@@ -1,0 +1,45 @@
+{
+  "profileVersion": "1.0.0",
+  "protocol": "FAXP",
+  "runtimeVersions": [
+    "0.1.1",
+    "0.2.0"
+  ],
+  "incomingVersions": [
+    "0.1.1",
+    "0.2.0"
+  ],
+  "compatibilityMatrix": {
+    "0.1.1": {
+      "0.1.1": "Compatible",
+      "0.2.0": "Degradable"
+    },
+    "0.2.0": {
+      "0.1.1": "Degradable",
+      "0.2.0": "Compatible"
+    }
+  },
+  "acceptedStatuses": [
+    "Compatible",
+    "Degradable"
+  ],
+  "rejectedStatus": "Incompatible",
+  "expectedReasonCodes": {
+    "Compatible": "ProtocolVersionCompatible",
+    "Degradable": "ProtocolVersionDegradable",
+    "Unsupported": "ProtocolVersionUnsupported",
+    "InvalidFormat": "ProtocolVersionInvalidFormat",
+    "Missing": "ProtocolVersionMissing",
+    "IncompatiblePair": "ProtocolVersionIncompatiblePair"
+  },
+  "requiredFixturePairs": [
+    "0.1.1->0.1.1",
+    "0.1.1->0.2.0",
+    "0.2.0->0.1.1",
+    "0.2.0->0.2.0"
+  ],
+  "requiredIncompatibleFixtureReasons": [
+    "ProtocolVersionUnsupported",
+    "ProtocolVersionInvalidFormat"
+  ]
+}

--- a/conformance/run_all_checks.py
+++ b/conformance/run_all_checks.py
@@ -45,6 +45,7 @@ def _suite_commands() -> list[tuple[str, list[str]]]:
         ("a2a_roundtrip", [python, str(TESTS_DIR / "run_a2a_roundtrip_translation.py")]),
         ("mcp_profile", [python, str(TESTS_DIR / "run_mcp_profile_check.py")]),
         ("mcp_watch_artifacts", [python, str(TESTS_DIR / "run_mcp_watch_artifacts.py")]),
+        ("protocol_compatibility_profile", [python, str(TESTS_DIR / "run_protocol_compatibility_profile.py")]),
         ("protocol_version_negotiation", [python, str(TESTS_DIR / "run_protocol_version_negotiation.py")]),
         ("cross_version_fixtures", [python, str(TESTS_DIR / "run_cross_version_fixtures.py")]),
         ("registry_apply", [python, str(TESTS_DIR / "run_apply_registry_update.py")]),

--- a/docs/governance/GOVERNANCE_INDEX.json
+++ b/docs/governance/GOVERNANCE_INDEX.json
@@ -1,6 +1,6 @@
 {
   "indexVersion": "1.0.0",
-  "generatedAt": "2026-02-22T20:00:00Z",
+  "generatedAt": "2026-02-23T10:00:00Z",
   "policyArtifacts": [
     "docs/governance/SCOPE_GUARDRAILS.md",
     "docs/rfc/RFC_TEMPLATE.md",
@@ -19,6 +19,7 @@
     "tests/run_registry_changelog_artifacts.py",
     "tests/run_decision_record_template.py",
     "tests/run_decision_record_artifacts.py",
+    "tests/run_protocol_compatibility_profile.py",
     "tests/run_governance_index.py",
     "tests/run_release_readiness.py"
   ],
@@ -28,6 +29,7 @@
     "registry_changelog_artifacts",
     "decision_record_template",
     "decision_record_artifacts",
+    "protocol_compatibility_profile",
     "governance_index",
     "release_readiness"
   ],
@@ -37,6 +39,7 @@
     "registry_changelog_artifacts": "tests/run_registry_changelog_artifacts.py",
     "decision_record_template": "tests/run_decision_record_template.py",
     "decision_record_artifacts": "tests/run_decision_record_artifacts.py",
+    "protocol_compatibility_profile": "tests/run_protocol_compatibility_profile.py",
     "governance_index": "tests/run_governance_index.py",
     "release_readiness": "tests/run_release_readiness.py"
   }

--- a/docs/governance/RELEASE_READINESS_CHECKLIST.md
+++ b/docs/governance/RELEASE_READINESS_CHECKLIST.md
@@ -34,6 +34,7 @@ Use this checklist as the final go/no-go gate before a tagged release.
     "docs/governance/DECISION_RECORDS_RUNBOOK.md",
     "docs/governance/CERTIFICATION_PLAYBOOK.md",
     "docs/governance/GOVERNANCE_INDEX.json",
+    "conformance/protocol_compatibility_profile.v1.json",
     "conformance/certification_registry.sample.json",
     "conformance/certification_registry.sample.after_update.json",
     "conformance/registry_update.sample.json",
@@ -48,6 +49,7 @@ Use this checklist as the final go/no-go gate before a tagged release.
     "tests/run_registry_changelog_artifacts.py",
     "tests/run_decision_record_template.py",
     "tests/run_decision_record_artifacts.py",
+    "tests/run_protocol_compatibility_profile.py",
     "tests/run_governance_index.py",
     "tests/run_release_readiness.py"
   ],
@@ -57,6 +59,7 @@ Use this checklist as the final go/no-go gate before a tagged release.
     "registry_changelog_artifacts",
     "decision_record_template",
     "decision_record_artifacts",
+    "protocol_compatibility_profile",
     "governance_index",
     "release_readiness"
   ],

--- a/tests/run_conformance_suite.py
+++ b/tests/run_conformance_suite.py
@@ -80,6 +80,10 @@ def main() -> int:
         "conformance suite must include mcp_watch_artifacts in default checks",
     )
     _assert(
+        "protocol_compatibility_profile" in listed_checks.stdout.splitlines(),
+        "conformance suite must include protocol_compatibility_profile in default checks",
+    )
+    _assert(
         "protocol_version_negotiation" in listed_checks.stdout.splitlines(),
         "conformance suite must include protocol_version_negotiation in default checks",
     )

--- a/tests/run_protocol_compatibility_profile.py
+++ b/tests/run_protocol_compatibility_profile.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Validate protocol compatibility profile artifact and runtime alignment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import re
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from faxp_mvp_simulation import (  # noqa: E402
+    FaxpProtocol,
+    negotiate_protocol_version,
+)
+
+
+PROFILE_PATH = PROJECT_ROOT / "conformance" / "protocol_compatibility_profile.v1.json"
+FIXTURES_PATH = PROJECT_ROOT / "tests" / "protocol_version_fixtures.json"
+SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def _assert(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    _assert(isinstance(payload, dict), f"{path.name} must contain a JSON object.")
+    return payload
+
+
+def _validate_versions(values: list[str], context: str) -> None:
+    _assert(values, f"{context} must be non-empty.")
+    _assert(len(values) == len(set(values)), f"{context} must not contain duplicates.")
+    for value in values:
+        _assert(SEMVER_PATTERN.fullmatch(value), f"{context} contains invalid semver: {value}")
+
+
+def main() -> int:
+    profile = _load_json(PROFILE_PATH)
+    fixtures_payload = _load_json(FIXTURES_PATH)
+    fixtures = fixtures_payload.get("fixtures")
+    _assert(isinstance(fixtures, list) and fixtures, "protocol_version_fixtures must be non-empty.")
+
+    required_fields = [
+        "profileVersion",
+        "protocol",
+        "runtimeVersions",
+        "incomingVersions",
+        "compatibilityMatrix",
+        "acceptedStatuses",
+        "rejectedStatus",
+        "expectedReasonCodes",
+        "requiredFixturePairs",
+        "requiredIncompatibleFixtureReasons",
+    ]
+    for field in required_fields:
+        _assert(field in profile, f"profile missing required field: {field}")
+
+    _assert(profile["protocol"] == FaxpProtocol.NAME, "profile protocol must match FaxpProtocol.NAME")
+
+    runtime_versions = [str(item) for item in profile["runtimeVersions"]]
+    incoming_versions = [str(item) for item in profile["incomingVersions"]]
+    _validate_versions(runtime_versions, "runtimeVersions")
+    _validate_versions(incoming_versions, "incomingVersions")
+    _assert(
+        set(runtime_versions) == set(incoming_versions),
+        "runtimeVersions and incomingVersions must include same version set.",
+    )
+    _assert(
+        set(incoming_versions) == set(FaxpProtocol.SUPPORTED_PROTOCOL_VERSIONS),
+        "profile incomingVersions must match FaxpProtocol.SUPPORTED_PROTOCOL_VERSIONS.",
+    )
+    _assert(
+        set(runtime_versions) == set(FaxpProtocol.VERSION_COMPATIBILITY_MATRIX.keys()),
+        "profile runtimeVersions must match FaxpProtocol.VERSION_COMPATIBILITY_MATRIX keys.",
+    )
+
+    compatibility_matrix = profile["compatibilityMatrix"]
+    _assert(isinstance(compatibility_matrix, dict), "compatibilityMatrix must be an object.")
+    _assert(
+        set(compatibility_matrix.keys()) == set(runtime_versions),
+        "compatibilityMatrix runtime keys must match runtimeVersions.",
+    )
+
+    accepted_statuses = set(str(item) for item in profile["acceptedStatuses"])
+    _assert(
+        accepted_statuses == {"Compatible", "Degradable"},
+        "acceptedStatuses must be exactly ['Compatible', 'Degradable'].",
+    )
+    _assert(profile["rejectedStatus"] == "Incompatible", "rejectedStatus must be 'Incompatible'.")
+
+    reason_codes = profile["expectedReasonCodes"]
+    _assert(isinstance(reason_codes, dict), "expectedReasonCodes must be an object.")
+    for key in [
+        "Compatible",
+        "Degradable",
+        "Unsupported",
+        "InvalidFormat",
+        "Missing",
+        "IncompatiblePair",
+    ]:
+        _assert(key in reason_codes, f"expectedReasonCodes missing key: {key}")
+
+    status_reason_map = {
+        "Compatible": reason_codes["Compatible"],
+        "Degradable": reason_codes["Degradable"],
+    }
+
+    fixture_status_pairs = set()
+    fixture_incompatible_reasons = set()
+    for fixture in fixtures:
+        fixture_id = str(fixture.get("id") or "").strip()
+        _assert(fixture_id, "each fixture requires non-empty id")
+        runtime = str(fixture.get("runtimeVersion") or "").strip()
+        incoming = str(fixture.get("incomingVersion") or "").strip()
+        expected_status = str(fixture.get("expectedStatus") or "").strip()
+        expected_reason = str(fixture.get("expectedReasonCode") or "").strip()
+        _assert(runtime and incoming and expected_status and expected_reason, f"{fixture_id}: missing fields")
+        fixture_status_pairs.add((runtime, incoming, expected_status))
+        if expected_status == "Incompatible":
+            fixture_incompatible_reasons.add(expected_reason)
+
+    for runtime in runtime_versions:
+        row = compatibility_matrix.get(runtime)
+        _assert(isinstance(row, dict), f"compatibilityMatrix[{runtime}] must be an object.")
+        _assert(
+            set(row.keys()) == set(incoming_versions),
+            f"compatibilityMatrix[{runtime}] incoming keys must match incomingVersions.",
+        )
+        runtime_matrix_row = FaxpProtocol.VERSION_COMPATIBILITY_MATRIX.get(runtime, {})
+        for incoming in incoming_versions:
+            expected_status = str(row[incoming])
+            _assert(
+                expected_status in {"Compatible", "Degradable", "Incompatible"},
+                f"invalid compatibility status {runtime}->{incoming}: {expected_status}",
+            )
+            _assert(
+                runtime_matrix_row.get(incoming) == expected_status,
+                (
+                    f"profile drift for runtime {runtime}, incoming {incoming}: "
+                    f"profile={expected_status} runtime={runtime_matrix_row.get(incoming)}"
+                ),
+            )
+            decision = negotiate_protocol_version(incoming, runtime_version=runtime)
+            _assert(
+                decision["status"] == expected_status,
+                (
+                    f"runtime decision mismatch for {runtime}->{incoming}: "
+                    f"expected {expected_status}, got {decision['status']}"
+                ),
+            )
+            expected_reason = status_reason_map.get(expected_status)
+            if expected_reason:
+                _assert(
+                    decision["reasonCode"] == expected_reason,
+                    (
+                        f"reason mismatch for {runtime}->{incoming}: "
+                        f"expected {expected_reason}, got {decision['reasonCode']}"
+                    ),
+                )
+            _assert(
+                (runtime, incoming, expected_status) in fixture_status_pairs,
+                f"missing fixture for runtime/incoming pair {runtime}->{incoming} ({expected_status})",
+            )
+
+    unsupported_decision = negotiate_protocol_version("9.9.9", runtime_version=runtime_versions[0])
+    _assert(
+        unsupported_decision["reasonCode"] == reason_codes["Unsupported"],
+        "unsupported reason code mismatch.",
+    )
+    invalid_format_decision = negotiate_protocol_version("v0.3", runtime_version=runtime_versions[0])
+    _assert(
+        invalid_format_decision["reasonCode"] == reason_codes["InvalidFormat"],
+        "invalid-format reason code mismatch.",
+    )
+    missing_decision = negotiate_protocol_version("", runtime_version=runtime_versions[0])
+    _assert(
+        missing_decision["reasonCode"] == reason_codes["Missing"],
+        "missing reason code mismatch.",
+    )
+
+    required_pairs = [str(item) for item in profile["requiredFixturePairs"]]
+    for pair in required_pairs:
+        _assert("->" in pair, f"requiredFixturePairs entry invalid: {pair}")
+        runtime, incoming = [item.strip() for item in pair.split("->", 1)]
+        matched = any(
+            fixture_runtime == runtime and fixture_incoming == incoming
+            for fixture_runtime, fixture_incoming, _ in fixture_status_pairs
+        )
+        _assert(matched, f"required fixture pair missing in fixtures: {pair}")
+
+    required_incompatible_reasons = [
+        str(item) for item in profile["requiredIncompatibleFixtureReasons"]
+    ]
+    for reason in required_incompatible_reasons:
+        _assert(
+            reason in fixture_incompatible_reasons,
+            f"required incompatible fixture reason missing: {reason}",
+        )
+
+    print("Protocol compatibility profile checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds a normative protocol compatibility profile artifact and enforces it across tests, conformance suite, CI, and governance release-readiness controls.

## Changes
- Added compatibility profile artifact:
  - `conformance/protocol_compatibility_profile.v1.json`
- Added profile/runtime sync test:
  - `tests/run_protocol_compatibility_profile.py`
- Added conformance suite check:
  - `conformance/run_all_checks.py` -> `protocol_compatibility_profile`
- Updated conformance suite orchestrator regression:
  - `tests/run_conformance_suite.py`
- Updated CI:
  - py_compile includes `tests/run_protocol_compatibility_profile.py`
  - new CI step runs `python tests/run_protocol_compatibility_profile.py`
- Updated governance/release-readiness requirements:
  - `docs/governance/RELEASE_READINESS_CHECKLIST.md`
  - `docs/governance/GOVERNANCE_INDEX.json`

## Why
This prevents drift between:
1. Runtime version negotiation behavior,
2. Fixture expectations,
3. Conformance requirements,
4. Governance release gates.

## Validation
- `./.venv/bin/python tests/run_protocol_compatibility_profile.py`
- `./.venv/bin/python tests/run_cross_version_fixtures.py`
- `./.venv/bin/python tests/run_conformance_suite.py`
- `./.venv/bin/python tests/run_governance_index.py`
- `./.venv/bin/python tests/run_release_readiness.py`
- `./.venv/bin/python conformance/run_all_checks.py --checks protocol_compatibility_profile --output /tmp/faxp_conformance_suite_report.protocol_compatibility_profile.json`

## Notes
- Staged only compatibility-profile and governance-wiring files.
- Left unrelated local untracked files untouched.
