### PR TITLE
Canonicalize verifier provenance labels across UI, runtime, and governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Hosted FMCSA adapter simulation path:
 ```bash
 python3 faxp_mvp_simulation.py \
   --provider FMCSA \
-  --fmcsa-source hosted-adapter \
+  --fmcsa-source implementer-adapter \
   --mc-number 498282 \
   --policy-profile-id US_FMCSA_BALANCED_V1 \
   --risk-tier 1 \
@@ -193,14 +193,14 @@ python3 faxp_mvp_simulation.py \
 Expected success line:
 - `Booking completed successfully ...`
 
-If verification fails in hosted-adapter mode, that is expected when authority/insurance checks fail for the MC or the adapter fails closed.
+If verification fails in adapter mode, that is expected when authority/insurance checks fail for the MC or the adapter fails closed.
 
 Degraded verification policy demo (provisional/hold path):
 
 ```bash
 python3 faxp_mvp_simulation.py \
   --provider FMCSA \
-  --fmcsa-source hosted-adapter \
+  --fmcsa-source implementer-adapter \
   --mc-number 498282 \
   --policy-profile-id US_FMCSA_BALANCED_V1 \
   --risk-tier 2 \
@@ -215,7 +215,7 @@ Hosted FMCSA adapter simulation path:
 ```bash
 python3 faxp_mvp_simulation.py \
   --provider FMCSA \
-  --fmcsa-source hosted-adapter \
+  --fmcsa-source implementer-adapter \
   --mc-number 498282 \
   --response Accept \
   --verification-status Success
@@ -277,7 +277,8 @@ FAXP_ENFORCE_TRUSTED_VERIFIER_REGISTRY="1"
 ```
 
 Notes:
-- Non-local mode requires `hosted-adapter` compliance verification and fails closed if the adapter URL is missing.
+- Non-local mode requires `implementer-adapter` or `vendor-direct` compliance verification and fails closed if the adapter URL is missing.
+- `hosted-adapter` remains accepted as a backward-compatible alias for `implementer-adapter`.
 - Non-local mode enforces trusted verifier registry validation on verification results.
 - Access key is enforced when `FAXP_APP_MODE` is non-local.
 

--- a/conformance/trusted_verifier_registry.sample.json
+++ b/conformance/trusted_verifier_registry.sample.json
@@ -6,19 +6,19 @@
       "providerId": "compliance.authority-record.adapter",
       "providerType": "Compliance",
       "status": "Active",
-      "allowedSources": ["hosted-adapter"],
+      "allowedSources": ["implementer-adapter", "vendor-direct", "hosted-adapter"],
       "allowedAssuranceLevels": ["AAL1"],
       "allowedAttestationKids": [],
-      "notes": "Builder-hosted compliance adapter provider IDs are validated against this registry."
+      "notes": "Builder-hosted or vendor-direct compliance provider IDs are validated against this registry."
     },
     {
       "providerId": "identity.liveness-document.adapter",
       "providerType": "Identity",
       "status": "Active",
-      "allowedSources": ["hosted-adapter"],
+      "allowedSources": ["implementer-adapter", "vendor-direct", "hosted-adapter"],
       "allowedAssuranceLevels": ["AAL2", "AAL3"],
       "allowedAttestationKids": [],
-      "notes": "Builder-hosted identity adapter provider IDs are validated against this registry."
+      "notes": "Builder-hosted or vendor-direct identity provider IDs are validated against this registry."
     },
     {
       "providerId": "compliance.authority-record.mock",

--- a/docs/governance/POLICY_PROFILES.md
+++ b/docs/governance/POLICY_PROFILES.md
@@ -31,6 +31,14 @@ This document defines booking-time degraded-mode semantics for verification poli
 - `US_FMCSA_SOFTHOLD_V1` -> `SoftHold`
 - `US_FMCSA_BALANCED_V1` -> `GraceCache`
 
+## Verification Source Labels
+- Canonical verifier source classes are:
+  - `vendor-direct`
+  - `implementer-adapter`
+  - `authority-only`
+  - `self-attested`
+- Legacy label `hosted-adapter` remains valid as a backward-compatible alias for `implementer-adapter`.
+
 ## Normative Test Matrix
 The following matrix is normative and consumed by conformance tests.
 

--- a/docs/governance/TRUSTED_VERIFIER_ADMISSION_REQUIREMENTS.md
+++ b/docs/governance/TRUSTED_VERIFIER_ADMISSION_REQUIREMENTS.md
@@ -24,6 +24,12 @@ This policy defines minimum admission criteria for verifier providers whose atte
    - `status`
    - `allowedSources`
    - `allowedAssuranceLevels`
+   - Canonical `allowedSources` values should use:
+     - `vendor-direct`
+     - `implementer-adapter`
+     - `authority-only`
+     - `self-attested`
+   - Legacy source labels may be retained for backward compatibility (for example, `hosted-adapter`).
 4. Verification result provider IDs must match a trusted registry entry.
 5. Verification result source must be in entry `allowedSources`.
 6. Verification result assurance level must be in entry `allowedAssuranceLevels`.

--- a/faxp_mvp_simulation.py
+++ b/faxp_mvp_simulation.py
@@ -1269,9 +1269,12 @@ def parse_args():
     )
     parser.add_argument(
         "--fmcsa-source",
-        choices=["authority-mock", "hosted-adapter"],
+        choices=["authority-mock", "hosted-adapter", "implementer-adapter", "vendor-direct"],
         default="authority-mock",
-        help="FMCSA verification source. 'hosted-adapter' calls a builder-hosted FMCSA wrapper API.",
+        help=(
+            "FMCSA verification source. 'implementer-adapter' and 'vendor-direct' are preferred labels; "
+            "'hosted-adapter' is retained as a backward-compatible alias."
+        ),
     )
     parser.add_argument(
         "--rate-model",
@@ -1863,8 +1866,16 @@ def _enforce_trusted_verifier_registry_result(result, context):
         )
 
     source = str(result.get("source") or "").strip().lower()
+    source_normalized = _normalize_verifier_source(source)
     allowed_sources = registry_entry.get("allowedSources") or []
-    if allowed_sources and source not in allowed_sources:
+    allowed_sources_normalized = {
+        _normalize_verifier_source(item) for item in allowed_sources if str(item or "").strip()
+    }
+    if (
+        allowed_sources
+        and source not in allowed_sources
+        and source_normalized not in allowed_sources_normalized
+    ):
         raise ValueError(
             f"{context}.source '{source}' is not allowed for trusted provider '{provider_id}'."
         )
@@ -1901,11 +1912,38 @@ def _validate_string_array(values, context):
         _bounded_string(item, f"{context}[{idx}]")
 
 
+def _normalize_verifier_source(source_value):
+    source = str(source_value or "").strip().lower()
+    if source in {"hosted-adapter", "implementer-adapter", "builder-hosted-adapter"}:
+        return "implementer-adapter"
+    if source in {"vendor-direct", "vendor-attestation"}:
+        return "vendor-direct"
+    if source in {"authority-mock", "mock-compliance", "authority-only", "live-fmcsa", "fmcsa-api"}:
+        return "authority-only"
+    if source in {"self-attested", "self-attest"}:
+        return "self-attested"
+    if source in {"cache", "cached-fmcsa", "fmcsa-cache"}:
+        return "cached-authority"
+    if source in {"mock-biometric", "simulated", "simulation"}:
+        return "simulated"
+    return source
+
+
+def _normalize_fmcsa_source(fmcsa_source):
+    source = str(fmcsa_source or "").strip().lower()
+    if source in {"hosted-adapter", "implementer-adapter", "vendor-direct"}:
+        return source
+    if source == "authority-mock":
+        return source
+    return source
+
+
 def _derive_verification_mode(verification_result):
     source = str((verification_result or {}).get("source") or "").strip().lower()
-    if source in {"hosted-adapter"}:
+    source_normalized = _normalize_verifier_source(source)
+    if source_normalized in {"implementer-adapter", "vendor-direct", "authority-only"}:
         return "Live"
-    if source in {"cache", "cached-fmcsa", "fmcsa-cache"}:
+    if source_normalized in {"cached-authority"}:
         return "Cached"
     return "Fallback"
 
@@ -2880,6 +2918,7 @@ def run_verification(
     """
     requested_provider = str(provider or "").strip()
     normalized_provider = normalize_verification_provider(requested_provider)
+    normalized_fmcsa_source = _normalize_fmcsa_source(fmcsa_source)
 
     def build_result(
         status_value,
@@ -2902,6 +2941,7 @@ def run_verification(
             "score": int(score_value),
             "token": token_value,
             "source": source_value,
+            "provenance": _normalize_verifier_source(source_value),
             "verifiedAt": now_utc(),
             "evidenceRef": f"sha256:{hashlib.sha256(token_value.encode('utf-8')).hexdigest()[:24]}",
         }
@@ -2916,7 +2956,11 @@ def run_verification(
             result["attestation"] = _build_verifier_attestation(attestation_payload)
         return result
 
-    if NON_LOCAL_MODE and normalized_provider == "FMCSA" and fmcsa_source != "hosted-adapter":
+    if NON_LOCAL_MODE and normalized_provider == "FMCSA" and normalized_fmcsa_source not in {
+        "hosted-adapter",
+        "implementer-adapter",
+        "vendor-direct",
+    }:
         verification_result = build_result(
             status_value="Fail",
             provider_value=NEUTRAL_VERIFICATION_PROVIDER_IDS["compliance_mock"],
@@ -2929,7 +2973,10 @@ def run_verification(
             source_authority="FMCSA",
             extra={
                 "mcNumber": _normalize_mc(mc_number),
-                "error": "Non-local mode requires hosted-adapter compliance verification source.",
+                "error": (
+                    "Non-local mode requires implementer-adapter or vendor-direct compliance "
+                    "verification source."
+                ),
             },
         )
         return verification_result, "None"
@@ -2950,7 +2997,7 @@ def run_verification(
 
     if normalized_provider == "FMCSA":
         fm_token = f"fmcsa-{uuid4().hex[:14]}"
-        if fmcsa_source == "hosted-adapter":
+        if normalized_fmcsa_source in {"hosted-adapter", "implementer-adapter", "vendor-direct"}:
             live = lookup_fmcsa_with_hosted_adapter(mc_number=mc_number)
             if live.get("ok"):
                 live_status = live.get("status", "Fail")
@@ -2964,7 +3011,7 @@ def run_verification(
                     assurance_level="AAL1",
                     score_value=score,
                     token_value=fm_token,
-                    source_value="hosted-adapter",
+                    source_value=normalized_fmcsa_source,
                     source_authority="FMCSA",
                     extra={
                         "mcNumber": _normalize_mc(mc_number),
@@ -2988,7 +3035,7 @@ def run_verification(
                 assurance_level="AAL1",
                 score_value=0,
                 token_value=fm_token,
-                source_value="hosted-adapter",
+                source_value=normalized_fmcsa_source,
                 source_authority="FMCSA",
                 extra={
                     "mcNumber": _normalize_mc(mc_number),
@@ -2997,7 +3044,12 @@ def run_verification(
             )
             return verification_result, "None"
 
-        if fmcsa_source not in {"authority-mock", "hosted-adapter"}:
+        if normalized_fmcsa_source not in {
+            "authority-mock",
+            "hosted-adapter",
+            "implementer-adapter",
+            "vendor-direct",
+        }:
             verification_result = build_result(
                 status_value="Fail",
                 provider_value=NEUTRAL_VERIFICATION_PROVIDER_IDS["compliance_mock"],

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -76,6 +76,13 @@ DEFAULT_POLICY_PROFILE = (
     if VERIFICATION_POLICY_PROFILE_ID in POLICY_PROFILE_OPTIONS
     else "US_FMCSA_BALANCED_V1"
 )
+FMCSA_SOURCE_LABELS = {
+    "authority-mock": "authority-mock",
+    "implementer-adapter": "implementer-adapter",
+    "vendor-direct": "vendor-direct",
+    # Backward-compatible alias.
+    "hosted-adapter": "implementer-adapter (legacy alias: hosted-adapter)",
+}
 
 
 def now_utc():
@@ -470,8 +477,8 @@ st.session_state.risk_tier_select = max(0, min(parsed_risk_tier, 3))
 if NON_LOCAL_MODE:
     st.session_state.provider_cloud_select = "ComplianceVerifier (Trusted Adapter)"
     st.session_state.provider_local_select = "FMCSA"
-    st.session_state.fmcsa_source_select_cloud = "hosted-adapter"
-    st.session_state.fmcsa_source_select_local = "hosted-adapter"
+    st.session_state.fmcsa_source_select_cloud = "implementer-adapter"
+    st.session_state.fmcsa_source_select_local = "implementer-adapter"
 elif CLOUD_SAFE_MODE and st.session_state.get("provider_cloud_select") not in {
     "ComplianceVerifier (Authority Mock)",
     "IdentityVerifier (Mock)",
@@ -572,50 +579,62 @@ with st.sidebar:
 
     if provider == "FMCSA":
         if NON_LOCAL_MODE:
-            fmcsa_source = "hosted-adapter"
+            fmcsa_source = "implementer-adapter"
             mc_number = st.text_input("MC Number", key="mc_number_input")
             if HOSTED_FMCSA_CONFIGURED:
-                st.caption("Trusted hosted compliance adapter mode is active.")
+                st.caption("Trusted external compliance endpoint mode is active.")
             else:
                 st.caption("Missing FAXP_FMCSA_ADAPTER_BASE_URL; verification fails closed in non-local mode.")
         elif CLOUD_SAFE_MODE:
             options = []
             if HOSTED_FMCSA_CONFIGURED:
-                options.append("hosted-adapter")
+                options.extend(["implementer-adapter", "vendor-direct"])
             options.append("authority-mock")
+            if st.session_state.get("fmcsa_source_select_cloud") == "hosted-adapter":
+                st.session_state.fmcsa_source_select_cloud = "implementer-adapter"
             if st.session_state.get("fmcsa_source_select_cloud") not in options:
                 st.session_state.fmcsa_source_select_cloud = options[0]
             cloud_fmcsa_mode = st.selectbox(
                 "FMCSA Source",
                 options,
                 key="fmcsa_source_select_cloud",
-                help="authority-mock uses local mock compliance scoring only.",
+                format_func=lambda key: FMCSA_SOURCE_LABELS.get(key, key),
+                help=(
+                    "authority-mock uses local mock compliance scoring only. "
+                    "implementer-adapter and vendor-direct require a configured trusted endpoint."
+                ),
             )
-            if cloud_fmcsa_mode == "hosted-adapter":
-                fmcsa_source = "hosted-adapter"
+            if cloud_fmcsa_mode in {"implementer-adapter", "vendor-direct"}:
+                fmcsa_source = cloud_fmcsa_mode
                 mc_number = st.text_input("MC Number", key="mc_number_input")
-                st.caption("Hosted FMCSA adapter mode enabled via FAXP_FMCSA_ADAPTER_BASE_URL.")
+                st.caption("Trusted compliance endpoint mode enabled via FAXP_FMCSA_ADAPTER_BASE_URL.")
             else:
                 fmcsa_source = "authority-mock"
                 mc_number = ""
                 st.caption("FMCSA authority-mock mode (no external API call).")
         else:
-            local_fmcsa_options = ["authority-mock", "hosted-adapter"]
+            local_fmcsa_options = ["authority-mock", "implementer-adapter", "vendor-direct"]
+            if st.session_state.get("fmcsa_source_select_local") == "hosted-adapter":
+                st.session_state.fmcsa_source_select_local = "implementer-adapter"
             if st.session_state.get("fmcsa_source_select_local") not in local_fmcsa_options:
                 st.session_state.fmcsa_source_select_local = local_fmcsa_options[0]
             fmcsa_source = st.selectbox(
                 "FMCSA Source",
                 local_fmcsa_options,
                 key="fmcsa_source_select_local",
-                help="authority-mock uses local mock compliance scoring only; hosted-adapter calls your hosted FMCSA wrapper.",
+                format_func=lambda key: FMCSA_SOURCE_LABELS.get(key, key),
+                help=(
+                    "authority-mock uses local mock compliance scoring only; "
+                    "implementer-adapter and vendor-direct call your trusted compliance endpoint."
+                ),
             )
             mc_number = st.text_input("MC Number", key="mc_number_input")
-            if fmcsa_source == "hosted-adapter":
+            if fmcsa_source in {"implementer-adapter", "vendor-direct"}:
                 if HOSTED_FMCSA_CONFIGURED:
-                    st.caption("Hosted FMCSA adapter mode enabled via FAXP_FMCSA_ADAPTER_BASE_URL.")
+                    st.caption("Trusted compliance endpoint mode enabled via FAXP_FMCSA_ADAPTER_BASE_URL.")
                 else:
                     st.caption(
-                        "Missing FAXP_FMCSA_ADAPTER_BASE_URL; hosted adapter calls will fail closed."
+                        "Missing FAXP_FMCSA_ADAPTER_BASE_URL; external compliance calls will fail closed."
                     )
             else:
                 st.caption("FMCSA authority-mock mode (no external API call).")
@@ -640,7 +659,7 @@ if run_clicked:
             st.session_state.status_line = "Unauthorized."
     elif NON_LOCAL_MODE and not HOSTED_FMCSA_CONFIGURED:
         st.session_state.status_line = (
-            "Hosted compliance adapter is required in non-local mode "
+            "Trusted compliance endpoint is required in non-local mode "
             "(set FAXP_FMCSA_ADAPTER_BASE_URL)."
         )
     else:

--- a/streamlit_state_logic.py
+++ b/streamlit_state_logic.py
@@ -7,8 +7,7 @@ from typing import Any, Mapping, MutableMapping
 
 
 def build_quick_presets(default_per_mile_bid: float) -> dict[str, dict[str, Any]]:
-    return {
-        "FMCSA hosted adapter (MC 498282)": {
+    implementer_adapter_preset = {
             "provider": "FMCSA",
             "policy_profile_id": "US_FMCSA_BALANCED_V1",
             "risk_tier": 1,
@@ -20,9 +19,13 @@ def build_quick_presets(default_per_mile_bid: float) -> dict[str, dict[str, Any]
             "verification_status": "Success",
             "no_match": False,
             "mc_number": "498282",
-            "fmcsa_source_local": "hosted-adapter",
-            "fmcsa_source_cloud": "hosted-adapter",
-        },
+            "fmcsa_source_local": "implementer-adapter",
+            "fmcsa_source_cloud": "implementer-adapter",
+    }
+    return {
+        "FMCSA implementer-adapter (MC 498282)": dict(implementer_adapter_preset),
+        # Backward-compatible preset alias for previous releases.
+        "FMCSA hosted adapter (MC 498282)": dict(implementer_adapter_preset),
         "FMCSA authority-mock": {
             "provider": "FMCSA",
             "policy_profile_id": "US_FMCSA_BALANCED_V1",
@@ -76,8 +79,8 @@ def build_quick_presets(default_per_mile_bid: float) -> dict[str, dict[str, Any]
             "verification_status": "Success",
             "no_match": False,
             "mc_number": "498282",
-            "fmcsa_source_local": "hosted-adapter",
-            "fmcsa_source_cloud": "hosted-adapter",
+            "fmcsa_source_local": "implementer-adapter",
+            "fmcsa_source_cloud": "implementer-adapter",
         },
     }
 
@@ -95,7 +98,7 @@ def default_sidebar_state(default_per_mile_bid: float) -> dict[str, Any]:
         "provider_local_select": "FMCSA",
         "provider_cloud_select": "ComplianceVerifier (Trusted Adapter)",
         "fmcsa_source_select_local": "authority-mock",
-        "fmcsa_source_select_cloud": "hosted-adapter",
+        "fmcsa_source_select_cloud": "implementer-adapter",
         "mc_number_input": "498282",
         "verification_status_select": "Success",
         "no_match_checkbox": False,
@@ -146,7 +149,7 @@ def apply_preset_to_state(
             "fmcsa_source_local", "authority-mock"
         )
         cloud_source = preset.get("fmcsa_source_cloud", "authority-mock")
-        if cloud_source == "hosted-adapter" and not hosted_fmcsa_configured:
+        if cloud_source in {"hosted-adapter", "implementer-adapter", "vendor-direct"} and not hosted_fmcsa_configured:
             cloud_source = "authority-mock"
         state["fmcsa_source_select_cloud"] = cloud_source
     else:

--- a/tests/run_streamlit_state_logic.py
+++ b/tests/run_streamlit_state_logic.py
@@ -27,6 +27,10 @@ def main() -> int:
     defaults = default_sidebar_state(2.62)
     presets = build_quick_presets(2.62)
     state: dict[str, object] = {}
+    _assert(
+        "FMCSA hosted adapter (MC 498282)" in presets,
+        "legacy hosted-adapter preset alias should remain available",
+    )
 
     ensure_state_defaults(state, defaults)
     _assert(state["quick_preset_select"] == "MockBiometric success", "default preset mismatch")
@@ -42,7 +46,7 @@ def main() -> int:
     apply_preset_to_state(
         state,
         presets,
-        "FMCSA hosted adapter (MC 498282)",
+        "FMCSA implementer-adapter (MC 498282)",
         hosted_fmcsa_configured=False,
     )
     _assert(
@@ -62,12 +66,12 @@ def main() -> int:
     apply_preset_to_state(
         state,
         presets,
-        "FMCSA hosted adapter (MC 498282)",
+        "FMCSA implementer-adapter (MC 498282)",
         hosted_fmcsa_configured=True,
     )
     _assert(
-        state["fmcsa_source_select_cloud"] == "hosted-adapter",
-        "hosted adapter should remain selected when configured",
+        state["fmcsa_source_select_cloud"] == "implementer-adapter",
+        "implementer adapter should remain selected when configured",
     )
 
     apply_preset_to_state(

--- a/tests/run_trusted_verifier_registry.py
+++ b/tests/run_trusted_verifier_registry.py
@@ -65,7 +65,7 @@ def main() -> int:
                 "providerId": "compliance.authority-record.adapter",
                 "providerType": "Compliance",
                 "status": "Active",
-                "allowedSources": ["hosted-adapter"],
+                "allowedSources": ["implementer-adapter", "vendor-direct"],
                 "allowedAssuranceLevels": ["AAL1"],
                 "allowedAttestationKids": [],
             },
@@ -93,6 +93,10 @@ def main() -> int:
         }
         sim._validate_verification_result(valid_result, "VerificationResult")  # noqa: SLF001
 
+        vendor_direct_result = dict(valid_result)
+        vendor_direct_result["source"] = "vendor-direct"
+        sim._validate_verification_result(vendor_direct_result, "VerificationResult")  # noqa: SLF001
+
         unknown_provider = dict(valid_result)
         unknown_provider["provider"] = "unknown.provider"
         _expect_failure(unknown_provider, "not in trusted verifier registry")
@@ -114,7 +118,7 @@ def main() -> int:
         _assert(fm_fail_result["status"] == "Fail", "non-local FMCSA authority-mock should fail")
         _assert(fm_fail_badge == "None", "non-local FMCSA authority-mock should not grant badge")
         _assert(
-            "requires hosted-adapter" in str(fm_fail_result.get("error", "")),
+            "requires implementer-adapter or vendor-direct" in str(fm_fail_result.get("error", "")),
             "non-local FMCSA failure reason mismatch",
         )
 


### PR DESCRIPTION
## Summary
This PR aligns verifier source semantics with the vendor-neutral policy model while preserving backward compatibility.

## What changed

### Runtime
- Added canonical verifier provenance normalization in `faxp_mvp_simulation.py`:
  - `implementer-adapter`
  - `vendor-direct`
  - `authority-only`
  - `self-attested`
- Kept legacy `hosted-adapter` behavior as backward-compatible alias.
- Non-local FMCSA enforcement now requires `implementer-adapter` or `vendor-direct`.
- Verification results now include normalized `provenance`.

### Streamlit UI/state
- Updated FMCSA source options and labels to canonical values in `streamlit_app.py`.
- Added migration guards for old session values (`hosted-adapter` -> `implementer-adapter`).
- Updated quick presets/defaults in `streamlit_state_logic.py` to canonical labels.
- Retained legacy preset alias:
  - `FMCSA hosted adapter (MC 498282)`

### Governance/docs
- Updated trusted verifier admission policy with canonical allowed source classes:
  - `vendor-direct`, `implementer-adapter`, `authority-only`, `self-attested`
- Clarified legacy alias support in:
  - `docs/governance/TRUSTED_VERIFIER_ADMISSION_REQUIREMENTS.md`
  - `docs/governance/POLICY_PROFILES.md`
  - `README.md`

### Conformance/tests
- Updated trusted registry sample allowed sources for adapter entries.
- Extended trusted verifier registry regression checks for canonical + alias source handling.
- Updated Streamlit state regression tests for new preset/source behavior.

## Scope check
- In scope: booking-time verification trust policy and certification semantics.
- Out of scope: dispatch operations, telematics/tracking lifecycle, POD/BOL custody, payment/settlement rails, FAXP-hosted verifier operations.

## Validation
- `./.venv/bin/python tests/run_streamlit_state_logic.py` ✅
- `./.venv/bin/python tests/run_trusted_verifier_registry.py` ✅
- `./.venv/bin/python tests/run_conformance_suite.py` ✅
- `./.venv/bin/python tests/run_release_readiness.py` ✅

## Notes
- Existing `hosted-adapter` integrations continue to work.
- Canonical labels are now preferred for new implementations and certification profiles.
