### PR TITLE
Add verification responsibility model and governance boundary links

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ This repository includes:
 - Provider integrations (FMCSA, biometric vendors, future verifiers) are adapter concerns and should remain outside protocol-core contracts.
 - `VerificationResult.provider` remains an opaque string in v0.2 compatibility schema; no vendor enum is required.
 - Production adapters are expected to be implementer-hosted; FAXP provides reference implementation + certification contracts.
+- Responsibility split is defined in `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`.
 
 ## Legacy Field Deprecation Timeline
 

--- a/docs/governance/CERTIFICATION_PLAYBOOK.md
+++ b/docs/governance/CERTIFICATION_PLAYBOOK.md
@@ -6,6 +6,8 @@ Purpose:
 - Keep FAXP protocol governance separate from adapter operations.
 - Standardize certification intake for any builder-hosted adapter.
 - Provide deterministic pass/fail checks before registry acceptance.
+- Responsibility boundary reference:
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`
 
 ## 1) Certification Tiers
 
@@ -49,6 +51,7 @@ Reference paths:
 - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/REGISTRY_OPERATIONS_RUNBOOK.md`
 - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/REGISTRY_CHANGELOG_POLICY.md`
 - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/TRUSTED_VERIFIER_ADMISSION_REQUIREMENTS.md`
+- `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`
 - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/GOVERNANCE_INDEX.json`
 - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/RELEASE_READINESS_CHECKLIST.md`
 - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/apply_registry_update.py`

--- a/docs/governance/GOVERNANCE_INDEX.json
+++ b/docs/governance/GOVERNANCE_INDEX.json
@@ -8,6 +8,7 @@
     "docs/governance/REGISTRY_ADMISSION_POLICY.md",
     "docs/governance/REGISTRY_CHANGELOG_POLICY.md",
     "docs/governance/TRUSTED_VERIFIER_ADMISSION_REQUIREMENTS.md",
+    "docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md",
     "docs/governance/CERTIFICATION_DECISION_RECORD_TEMPLATE.md",
     "docs/governance/DECISION_RECORDS_RUNBOOK.md",
     "docs/governance/RELEASE_READINESS_CHECKLIST.md",

--- a/docs/governance/RELEASE_READINESS_CHECKLIST.md
+++ b/docs/governance/RELEASE_READINESS_CHECKLIST.md
@@ -31,6 +31,7 @@ Use this checklist as the final go/no-go gate before a tagged release.
     "docs/governance/REGISTRY_ADMISSION_POLICY.md",
     "docs/governance/REGISTRY_CHANGELOG_POLICY.md",
     "docs/governance/TRUSTED_VERIFIER_ADMISSION_REQUIREMENTS.md",
+    "docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md",
     "docs/governance/CERTIFICATION_DECISION_RECORD_TEMPLATE.md",
     "docs/governance/DECISION_RECORDS_RUNBOOK.md",
     "docs/governance/CERTIFICATION_PLAYBOOK.md",

--- a/docs/governance/SCOPE_GUARDRAILS.md
+++ b/docs/governance/SCOPE_GUARDRAILS.md
@@ -37,6 +37,7 @@ These guardrails prevent scope creep into dispatch operations, tracking operatio
 - `DispatchAuthorization` in `ExecutionReport` is currently treated as a booking-time policy gate only.
 - It must not expand into dispatch orchestration message types or downstream dispatch lifecycle state in protocol core.
 - FAXP may enforce trusted-attestation policy and verifier admission criteria, but verifier execution remains implementer-hosted.
+- Verification ownership boundaries are documented in `docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`.
 
 ## Change Control
 - Any proposed expansion into an out-of-scope domain requires an RFC using `/docs/rfc/RFC_TEMPLATE.md`.

--- a/docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md
+++ b/docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md
@@ -1,0 +1,49 @@
+# Verification Responsibility Model
+
+## Purpose
+Define clear ownership boundaries for verification in FAXP so protocol governance remains neutral and implementers can integrate trusted providers without vendor lock-in.
+
+## Ownership by Role
+
+### 1) FAXP Foundation / Protocol Governance
+- Defines protocol envelope, validation, signing, replay/TTL, and conformance requirements.
+- Defines trusted verifier admission policy and certification criteria.
+- Validates attestation format, signature, trust-registry membership, and policy decision behavior.
+- Does not host verifier services, vendor APIs, or production adapter infrastructure.
+- Does not store implementer production credentials for verifier vendors.
+
+### 2) Implementer / Agent Builder / TMS Integrator
+- Chooses verifier providers based on business policy and certification status.
+- Hosts integration runtime when needed (for example, implementer-adapter model).
+- Manages vendor credentials, endpoint security, key rotation, and incident response.
+- Emits verification results that satisfy FAXP trust and schema requirements.
+- Owns SLA and operational continuity commitments to broker/carrier/shipper users.
+
+### 3) Verifier Vendor (External Service)
+- Performs compliance or identity checks under its own operating model.
+- Provides signed attestations or API outputs that can be translated into FAXP-compatible verification results.
+- Owns source-data quality, service availability, and verifier-specific evidence provenance.
+
+### 4) Broker/Carrier/Shipper Organizations Using Agents
+- Set policy thresholds (risk tiers, booking behavior on verifier outage, exception process).
+- Approve or deny operational exceptions per internal policy.
+- Own legal/compliance accountability for production dispatch and commercial decisions.
+
+## Canonical Source Classes
+- `vendor-direct`: agent/integrator consumes verifier vendor attestation directly.
+- `implementer-adapter`: implementer-hosted adapter normalizes vendor output to FAXP contract.
+- `authority-only`: authority lookup path without higher-trust vendor attestation.
+- `self-attested`: lowest-trust source, policy-restricted for production use.
+
+Legacy alias:
+- `hosted-adapter` is accepted for backward compatibility and maps to `implementer-adapter`.
+
+## Enforcement Boundary
+- FAXP enforces attestation validity and trust policy.
+- FAXP does not execute external verification itself.
+- Non-local runs fail closed when trusted verification requirements are unmet.
+
+## Certification Implications
+- Admission checks evaluate provider/source/assurance alignment and signature validity.
+- Certification approves conformance posture, not vendor business endorsement.
+- Multiple verifier vendors can be admitted if they satisfy the same objective criteria.


### PR DESCRIPTION
## Summary
Adds an explicit verification responsibility model so ownership boundaries are unambiguous for contributors, implementers, and certification reviewers.

## Changes
- Added `docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`:
  - role ownership (FAXP governance, implementers, verifier vendors, participating orgs)
  - canonical source classes (`vendor-direct`, `implementer-adapter`, `authority-only`, `self-attested`)
  - enforcement boundary and certification implications
- Linked this model from:
  - `README.md`
  - `docs/governance/CERTIFICATION_PLAYBOOK.md`
  - `docs/governance/SCOPE_GUARDRAILS.md`
- Added artifact coverage in:
  - `docs/governance/GOVERNANCE_INDEX.json`
  - `docs/governance/RELEASE_READINESS_CHECKLIST.md`

## Scope
Documentation/governance clarity only. No protocol message or runtime behavior changes.

## Validation
- `./.venv/bin/python tests/run_governance_index.py`
- `./.venv/bin/python tests/run_release_readiness.py`
- `./.venv/bin/python tests/run_conformance_suite.py`
