### PR TITLE
Normalize Streamlit verification labels to compliance/identity naming

### DIFF
--- a/docs/governance/POLICY_PROFILES.md
+++ b/docs/governance/POLICY_PROFILES.md
@@ -50,7 +50,7 @@ The following matrix is normative and consumed by conformance tests.
     "riskTier": 1,
     "verification": {
       "status": "Success",
-      "source": "hosted-adapter",
+      "source": "implementer-adapter",
       "provider": "compliance.authority-record.live"
     },
     "expected": {
@@ -65,7 +65,7 @@ The following matrix is normative and consumed by conformance tests.
     "riskTier": 0,
     "verification": {
       "status": "Fail",
-      "source": "hosted-adapter",
+      "source": "implementer-adapter",
       "provider": "compliance.authority-record.live"
     },
     "expected": {
@@ -80,8 +80,8 @@ The following matrix is normative and consumed by conformance tests.
     "riskTier": 0,
     "verification": {
       "status": "Fail",
-      "source": "hosted-adapter",
-      "error": "Hosted adapter network error."
+      "source": "implementer-adapter",
+      "error": "Implementer adapter network error."
     },
     "expected": {
       "DispatchAuthorization": "Allowed",
@@ -95,8 +95,8 @@ The following matrix is normative and consumed by conformance tests.
     "riskTier": 2,
     "verification": {
       "status": "Fail",
-      "source": "hosted-adapter",
-      "error": "Hosted adapter network error."
+      "source": "implementer-adapter",
+      "error": "Implementer adapter network error."
     },
     "expected": {
       "DispatchAuthorization": "Hold",
@@ -112,8 +112,8 @@ The following matrix is normative and consumed by conformance tests.
     "exceptionApprovalRef": "APPROVAL-123",
     "verification": {
       "status": "Fail",
-      "source": "hosted-adapter",
-      "error": "Hosted adapter network error."
+      "source": "implementer-adapter",
+      "error": "Implementer adapter network error."
     },
     "expected": {
       "DispatchAuthorization": "Allowed",
@@ -128,8 +128,8 @@ The following matrix is normative and consumed by conformance tests.
     "riskTier": 1,
     "verification": {
       "status": "Fail",
-      "source": "hosted-adapter",
-      "error": "Hosted adapter network error."
+      "source": "implementer-adapter",
+      "error": "Implementer adapter network error."
     },
     "expected": {
       "DispatchAuthorization": "Blocked",
@@ -143,8 +143,8 @@ The following matrix is normative and consumed by conformance tests.
     "riskTier": 1,
     "verification": {
       "status": "Fail",
-      "source": "hosted-adapter",
-      "error": "Hosted adapter network error."
+      "source": "implementer-adapter",
+      "error": "Implementer adapter network error."
     },
     "expected": {
       "DispatchAuthorization": "Hold",
@@ -160,8 +160,8 @@ The following matrix is normative and consumed by conformance tests.
     "exceptionApprovalRef": "APPROVAL-CRITICAL-1",
     "verification": {
       "status": "Fail",
-      "source": "hosted-adapter",
-      "error": "Hosted adapter network error."
+      "source": "implementer-adapter",
+      "error": "Implementer adapter network error."
     },
     "expected": {
       "DispatchAuthorization": "Blocked",

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -71,12 +71,17 @@ POLICY_PROFILE_OPTIONS = [
     "US_FMCSA_SOFTHOLD_V1",
     "US_FMCSA_STRICT_V1",
 ]
+POLICY_PROFILE_LABELS = {
+    "US_FMCSA_BALANCED_V1": "US Compliance Balanced v1 (GraceCache)",
+    "US_FMCSA_SOFTHOLD_V1": "US Compliance SoftHold v1",
+    "US_FMCSA_STRICT_V1": "US Compliance Strict v1 (HardBlock)",
+}
 DEFAULT_POLICY_PROFILE = (
     VERIFICATION_POLICY_PROFILE_ID
     if VERIFICATION_POLICY_PROFILE_ID in POLICY_PROFILE_OPTIONS
     else "US_FMCSA_BALANCED_V1"
 )
-FMCSA_SOURCE_LABELS = {
+COMPLIANCE_SOURCE_LABELS = {
     "authority-mock": "authority-mock",
     "implementer-adapter": "implementer-adapter",
     "vendor-direct": "vendor-direct",
@@ -531,6 +536,7 @@ with st.sidebar:
         "Verification Policy Profile",
         POLICY_PROFILE_OPTIONS,
         key="policy_profile_select",
+        format_func=lambda value: POLICY_PROFILE_LABELS.get(value, value),
     )
     risk_tier = st.selectbox(
         "Risk Tier",
@@ -606,10 +612,10 @@ with st.sidebar:
             if st.session_state.get("fmcsa_source_select_cloud") not in options:
                 st.session_state.fmcsa_source_select_cloud = options[0]
             cloud_fmcsa_mode = st.selectbox(
-                "FMCSA Source",
+                "Compliance Source",
                 options,
                 key="fmcsa_source_select_cloud",
-                format_func=lambda key: FMCSA_SOURCE_LABELS.get(key, key),
+                format_func=lambda key: COMPLIANCE_SOURCE_LABELS.get(key, key),
                 help=(
                     "authority-mock uses local mock compliance scoring only. "
                     "implementer-adapter and vendor-direct require a configured trusted endpoint."
@@ -622,7 +628,7 @@ with st.sidebar:
             else:
                 fmcsa_source = "authority-mock"
                 mc_number = ""
-                st.caption("FMCSA authority-mock mode (no external API call).")
+                st.caption("Compliance authority-mock mode (no external API call).")
         else:
             local_fmcsa_options = ["authority-mock", "implementer-adapter", "vendor-direct"]
             if st.session_state.get("fmcsa_source_select_local") == "hosted-adapter":
@@ -630,10 +636,10 @@ with st.sidebar:
             if st.session_state.get("fmcsa_source_select_local") not in local_fmcsa_options:
                 st.session_state.fmcsa_source_select_local = local_fmcsa_options[0]
             fmcsa_source = st.selectbox(
-                "FMCSA Source",
+                "Compliance Source",
                 local_fmcsa_options,
                 key="fmcsa_source_select_local",
-                format_func=lambda key: FMCSA_SOURCE_LABELS.get(key, key),
+                format_func=lambda key: COMPLIANCE_SOURCE_LABELS.get(key, key),
                 help=(
                     "authority-mock uses local mock compliance scoring only; "
                     "implementer-adapter and vendor-direct call your trusted compliance endpoint."
@@ -648,7 +654,7 @@ with st.sidebar:
                         "Missing FAXP_FMCSA_ADAPTER_BASE_URL; external compliance calls will fail closed."
                     )
             else:
-                st.caption("FMCSA authority-mock mode (no external API call).")
+                st.caption("Compliance authority-mock mode (no external API call).")
     else:
         fmcsa_source = "authority-mock"
         mc_number = ""
@@ -731,6 +737,7 @@ else:
         {
             "runId": diag.get("run_id", "n/a"),
             "provider": diag.get("provider", "n/a"),
+            "complianceSource": diag.get("fmcsa_source", "n/a"),
             "fmcsaSource": diag.get("fmcsa_source", "n/a"),
             "hostedFmcsaConfigured": diag.get("hosted_fmcsa_configured"),
             "cloudSafeMode": diag.get("cloud_safe_mode"),
@@ -751,7 +758,7 @@ else:
     )
     c1, c2, c3, c4 = st.columns(4)
     c1.metric("Configured Provider", diag.get("provider", "n/a"))
-    c2.metric("FMCSA Source", diag.get("fmcsa_source", "n/a"))
+    c2.metric("Compliance Source", diag.get("fmcsa_source", "n/a"))
     c3.metric(
         "FMCSA Adapter",
         "Configured" if diag.get("hosted_fmcsa_configured") else "Missing",

--- a/streamlit_state_logic.py
+++ b/streamlit_state_logic.py
@@ -23,9 +23,26 @@ def build_quick_presets(default_per_mile_bid: float) -> dict[str, dict[str, Any]
             "fmcsa_source_cloud": "implementer-adapter",
     }
     return {
-        "FMCSA implementer-adapter (MC 498282)": dict(implementer_adapter_preset),
+        "Compliance implementer-adapter (MC 498282)": dict(implementer_adapter_preset),
         # Backward-compatible preset alias for previous releases.
         "FMCSA hosted adapter (MC 498282)": dict(implementer_adapter_preset),
+        "FMCSA implementer-adapter (MC 498282)": dict(implementer_adapter_preset),
+        "Compliance authority-mock": {
+            "provider": "FMCSA",
+            "policy_profile_id": "US_FMCSA_BALANCED_V1",
+            "risk_tier": 1,
+            "exception_approved": False,
+            "exception_approval_ref": "",
+            "rate_model": "PerMile",
+            "bid_amount": float(default_per_mile_bid),
+            "response_type": "Accept",
+            "verification_status": "Success",
+            "no_match": False,
+            "mc_number": "498282",
+            "fmcsa_source_local": "authority-mock",
+            "fmcsa_source_cloud": "authority-mock",
+        },
+        # Backward-compatible preset alias for previous releases.
         "FMCSA authority-mock": {
             "provider": "FMCSA",
             "policy_profile_id": "US_FMCSA_BALANCED_V1",

--- a/tests/run_streamlit_state_logic.py
+++ b/tests/run_streamlit_state_logic.py
@@ -31,6 +31,10 @@ def main() -> int:
         "FMCSA hosted adapter (MC 498282)" in presets,
         "legacy hosted-adapter preset alias should remain available",
     )
+    _assert(
+        "Compliance implementer-adapter (MC 498282)" in presets,
+        "compliance implementer-adapter preset should be available",
+    )
 
     ensure_state_defaults(state, defaults)
     _assert(state["quick_preset_select"] == "MockBiometric success", "default preset mismatch")
@@ -46,7 +50,7 @@ def main() -> int:
     apply_preset_to_state(
         state,
         presets,
-        "FMCSA implementer-adapter (MC 498282)",
+        "Compliance implementer-adapter (MC 498282)",
         hosted_fmcsa_configured=False,
     )
     _assert(
@@ -66,7 +70,7 @@ def main() -> int:
     apply_preset_to_state(
         state,
         presets,
-        "FMCSA implementer-adapter (MC 498282)",
+        "Compliance implementer-adapter (MC 498282)",
         hosted_fmcsa_configured=True,
     )
     _assert(


### PR DESCRIPTION
## Summary
- Update Streamlit user-facing terminology from FMCSA-specific wording to neutral compliance wording.
- Keep existing policy/profile IDs for compatibility, but render clearer labels in UI.
- Align normative policy matrix examples with canonical source naming.

## Changes
- `streamlit_app.py`
  - Rename sidebar/diagnostics label:
    - `FMCSA Source` -> `Compliance Source`
  - Add friendly labels for verification policy profile IDs:
    - `US_FMCSA_BALANCED_V1` -> `US Compliance Balanced v1 (GraceCache)`
    - `US_FMCSA_SOFTHOLD_V1` -> `US Compliance SoftHold v1`
    - `US_FMCSA_STRICT_V1` -> `US Compliance Strict v1 (HardBlock)`
  - Keep compatibility fields in diagnostics payload (`fmcsaSource`) and add `complianceSource`.

- `streamlit_state_logic.py`
  - Add modern quick preset names using `Compliance ...`.
  - Keep legacy FMCSA preset aliases to avoid breaking prior flows.

- `tests/run_streamlit_state_logic.py`
  - Update assertions for new preset names.
  - Preserve checks for legacy preset alias compatibility.

- `docs/governance/POLICY_PROFILES.md`
  - Replace matrix `source: "hosted-adapter"` with `source: "implementer-adapter"`.
  - Update outage error text to `Implementer adapter network error.`

## Why
- Better aligns UI and docs with the vendor-neutral verification model.
- Reduces confusion between protocol-neutral compliance verification and FMCSA-specific implementation details.
- Preserves backward compatibility for existing profile IDs and source aliases.

## Scope
- No protocol message type changes.
- No schema changes.
- No runtime policy semantics changed.
- Naming and documentation consistency only.

## Validation
- `./.venv/bin/python tests/run_streamlit_state_logic.py`
- `./.venv/bin/python tests/run_policy_profile_sync.py`
- `./.venv/bin/python tests/run_policy_decisions.py`
- `./.venv/bin/python tests/run_verification_policy_profile.py`
- `./.venv/bin/python tests/run_release_readiness.py`
