### PR TITLE
Add vendor-direct certification runbook and enforce governance/readiness linkage

### DIFF
--- a/docs/governance/GOVERNANCE_INDEX.json
+++ b/docs/governance/GOVERNANCE_INDEX.json
@@ -1,6 +1,6 @@
 {
   "indexVersion": "1.0.0",
-  "generatedAt": "2026-02-26T00:10:00Z",
+  "generatedAt": "2026-02-26T00:40:00Z",
   "policyArtifacts": [
     "docs/governance/SCOPE_GUARDRAILS.md",
     "docs/rfc/RFC_TEMPLATE.md",
@@ -13,6 +13,7 @@
     "docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md",
     "docs/governance/CERTIFICATION_DECISION_RECORD_TEMPLATE.md",
     "docs/governance/DECISION_RECORDS_RUNBOOK.md",
+    "docs/governance/VENDOR_DIRECT_CERTIFICATION_RUNBOOK.md",
     "docs/governance/RELEASE_READINESS_CHECKLIST.md",
     "docs/governance/CERTIFICATION_PLAYBOOK.md"
   ],

--- a/docs/governance/RELEASE_READINESS_CHECKLIST.md
+++ b/docs/governance/RELEASE_READINESS_CHECKLIST.md
@@ -11,6 +11,7 @@ Use this checklist as the final go/no-go gate before a tagged release.
 - [ ] Protocol schemas and simulation artifacts are present and version-aligned.
 - [ ] Security scripts and baseline policies are present.
 - [ ] Governance policies, templates, and runbooks are present.
+- [ ] Vendor-direct certification runbook is present and references attestation + decision-link checks.
 - [ ] Conformance and certification artifacts are present.
 - [ ] CI and conformance suite include all mandatory release-readiness checks.
 
@@ -36,6 +37,7 @@ Use this checklist as the final go/no-go gate before a tagged release.
     "docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md",
     "docs/governance/CERTIFICATION_DECISION_RECORD_TEMPLATE.md",
     "docs/governance/DECISION_RECORDS_RUNBOOK.md",
+    "docs/governance/VENDOR_DIRECT_CERTIFICATION_RUNBOOK.md",
     "docs/governance/CERTIFICATION_PLAYBOOK.md",
     "docs/governance/GOVERNANCE_INDEX.json",
     "conformance/rate_model_profile.v1.json",

--- a/docs/governance/VENDOR_DIRECT_CERTIFICATION_RUNBOOK.md
+++ b/docs/governance/VENDOR_DIRECT_CERTIFICATION_RUNBOOK.md
@@ -1,0 +1,48 @@
+# Vendor-Direct Certification Runbook
+
+This runbook defines the minimum operator workflow for vendor-direct verifier certification artifacts.
+
+Purpose:
+- Keep FAXP protocol governance and certification deterministic.
+- Ensure vendor-direct attestation evidence is signed, auditable, and referenced by decision artifacts.
+- Prevent release drift where profile/registry/decision records are not linked.
+
+Scope:
+- In scope: certification artifacts and conformance checks for vendor-direct verification evidence.
+- Out of scope: hosting verifier infrastructure, operating vendor APIs, or managing vendor production credentials.
+
+## Required Artifacts
+1. `conformance/vendor_direct_verifier_profile.v1.json`
+2. `conformance/vendor_direct_attestation.sample.json`
+3. `conformance/trusted_verifier_registry.sample.json`
+4. `conformance/certification_decision_record.sample.json`
+5. `conformance/attestation_keys.sample.json`
+
+## Procedure
+1. Ensure provider identity in attestation matches trusted registry `providerId`.
+2. Ensure attestation `source` and `provenance` normalize to `vendor-direct`.
+3. Ensure attestation `attestation.alg/kid/sig` are present and valid.
+4. Ensure decision record includes:
+- `VENDOR_DIRECT_ATTESTATION_PASS` in `decisionReasonCodes`
+- `VendorDirectAttestation` evidence link to `conformance/vendor_direct_attestation.sample.json`
+5. Run required checks (below) and keep outputs green before merge/release.
+
+## Validation Commands
+```bash
+./.venv/bin/python tests/run_vendor_direct_profile.py
+./.venv/bin/python tests/run_vendor_direct_attestation_flow.py
+./.venv/bin/python tests/run_decision_record_artifacts.py
+FAXP_APP_MODE=local ./.venv/bin/python conformance/run_all_checks.py --output /tmp/faxp_vendor_direct_conformance.json
+```
+
+## Expected Outcomes
+1. Vendor-direct profile and trusted-registry alignment pass.
+2. Vendor-direct attestation signature/provenance checks pass.
+3. Certification decision record links attestation evidence and reason code correctly.
+4. Conformance suite includes and passes `vendor_direct_attestation_flow`.
+
+## Governance References
+1. `docs/governance/CERTIFICATION_PLAYBOOK.md`
+2. `docs/governance/TRUSTED_VERIFIER_ADMISSION_REQUIREMENTS.md`
+3. `docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`
+4. `docs/governance/RELEASE_READINESS_CHECKLIST.md`


### PR DESCRIPTION
Adds a dedicated vendor-direct certification runbook and registers it in governance index and release-readiness artifacts so certification review remains explicit and auditable.

What changed:

Added docs/governance/VENDOR_DIRECT_CERTIFICATION_RUNBOOK.md with:
required artifacts
deterministic procedure
required validation commands
expected outcomes and governance references
Updated docs/governance/GOVERNANCE_INDEX.json:
added vendor-direct runbook to policyArtifacts
refreshed generatedAt
Updated docs/governance/RELEASE_READINESS_CHECKLIST.md:
added manual checklist line for vendor-direct runbook presence
added vendor-direct runbook to requiredArtifacts block
Validation:

tests/run_governance_index.py
tests/run_release_readiness.py (FAXP_APP_MODE=local)
tests/run_conformance_suite.py (FAXP_APP_MODE=local)`