### PR TITLE
Add one-command local release smoke script and README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ This repository includes:
 - Security controls (message signing, verifier signing, replay/TTL, key rotation, incident drill).
 - CI checks for parser regressions, Streamlit state regressions, and schema compatibility.
 
+## One-Command Local Release Smoke
+
+Run the same local-mode gate path used for release validation:
+
+```bash
+cd /Users/zglitch009/projects/logistics-ai/FIX-F
+./scripts/run_release_smoke_local.sh
+```
+
+Optional conformance report path:
+
+```bash
+./scripts/run_release_smoke_local.sh /tmp/faxp_conformance_suite_report.local_smoke.json
+```
+
 ## Release Checkpoints
 
 - `v0.2.0-alpha.1`: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/releases/RELEASE_NOTES_v0.2.0-alpha.1.md`

--- a/scripts/run_release_smoke_local.sh
+++ b/scripts/run_release_smoke_local.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ -x "$PROJECT_DIR/.venv/bin/python" ]]; then
+  PYTHON_BIN="$PROJECT_DIR/.venv/bin/python"
+else
+  PYTHON_BIN="$(command -v python3 || true)"
+fi
+
+if [[ -z "$PYTHON_BIN" ]]; then
+  echo "python3 not found in PATH." >&2
+  exit 1
+fi
+
+REPORT_PATH="${1:-/tmp/faxp_conformance_suite_report.local_smoke.json}"
+
+echo "[ReleaseSmokeLocal] Project: $PROJECT_DIR"
+echo "[ReleaseSmokeLocal] Python:  $PYTHON_BIN"
+echo "[ReleaseSmokeLocal] Report:  $REPORT_PATH"
+echo "[ReleaseSmokeLocal] Forcing FAXP_APP_MODE=local for this run."
+
+(
+  export FAXP_APP_MODE=local
+  "$PROJECT_DIR/scripts/run_a2a_conformance.sh"
+  "$PROJECT_DIR/scripts/run_mcp_conformance.sh"
+  "$PYTHON_BIN" "$PROJECT_DIR/conformance/run_all_checks.py" --output "$REPORT_PATH"
+  "$PYTHON_BIN" "$PROJECT_DIR/tests/run_release_readiness.py"
+)
+
+echo "[ReleaseSmokeLocal] Complete."


### PR DESCRIPTION
Adds a contributor-friendly local release smoke command that runs the exact gate sequence in local mode.

What changed:

Added scripts/run_release_smoke_local.sh
forces FAXP_APP_MODE=local
runs A2A conformance
runs MCP conformance
runs full conformance suite report
runs release readiness test
Added README section: "One-Command Local Release Smoke" with usage and optional report path.
Validation:

./scripts/run_release_smoke_local.sh /tmp/faxp_conformance_suite_report.local_smoke.test.json
Result: all checks passed (39/39), release readiness passed.`