### PR TITLE
Run canonical local release smoke script in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
             scripts/incident_drill.sh \
             scripts/run_a2a_conformance.sh \
             scripts/run_mcp_conformance.sh \
+            scripts/run_release_smoke_local.sh \
             scripts/run_secure_demo.sh \
             conformance/quickstart/make_conformance_bundle.sh
 
@@ -69,6 +70,7 @@ jobs:
             scripts/incident_drill.sh \
             scripts/run_a2a_conformance.sh \
             scripts/run_mcp_conformance.sh \
+            scripts/run_release_smoke_local.sh \
             scripts/run_secure_demo.sh \
             conformance/quickstart/make_conformance_bundle.sh
 
@@ -200,6 +202,20 @@ jobs:
       - name: Release readiness checks
         run: |
           python tests/run_release_readiness.py
+
+      - name: Canonical local release smoke script
+        run: |
+          REPORT_PATH="$RUNNER_TEMP/faxp_conformance_suite_report.ci_local_smoke.json"
+          ./scripts/run_release_smoke_local.sh "$REPORT_PATH"
+          python - <<'PY' "$REPORT_PATH"
+          import json
+          import sys
+          from pathlib import Path
+          report_path = Path(sys.argv[1])
+          payload = json.loads(report_path.read_text(encoding="utf-8"))
+          print("[INFO] Canonical smoke summary:", json.dumps(payload.get("summary", {}), sort_keys=True))
+          print("[INFO] Canonical smoke report:", str(report_path))
+          PY
 
       - name: Booking-plane commercial terms governance checks
         run: |


### PR DESCRIPTION
Adds a canonical CI gate step that runs the same one-command local release smoke path contributors use.

What changed:

Updated .github/workflows/ci.yml to:
include scripts/run_release_smoke_local.sh in executable + shell syntax checks
add "Canonical local release smoke script" step
run script with report output path under RUNNER_TEMP
print conformance summary and report path in CI logs
Why:

Aligns local and CI gate behavior
Reduces environment-mode drift by forcing local-mode release smoke path in one deterministic step
Improves debugging with explicit report location and summary output
Validation:

tests/run_governance_index.py
tests/run_release_readiness.py (FAXP_APP_MODE=local)
scripts/run_release_smoke_local.sh (39/39 passed)`