### PR TITLE
Add booking-plane detention terms model and enforce conformance

### DIFF
--- a/conformance/accessorial_terms_profile.v1.json
+++ b/conformance/accessorial_terms_profile.v1.json
@@ -3,7 +3,7 @@
   "profileId": "accessorial-commercial-terms.v1",
   "protocol": "FAXP",
   "scope": "booking-plane-commercial-terms",
-  "description": "Canonical booking-time accessorial policy profile for pricing mode, payer/payee allocation, and evidence intent. Settlement and payment execution remain out of FAXP core scope.",
+  "description": "Canonical booking-time accessorial policy profile for pricing mode, payer/payee allocation, evidence intent, and detention commercial terms. Settlement and payment execution remain out of FAXP core scope.",
   "requiredPolicyFields": [
     "AllowedTypes",
     "RequiresApproval",
@@ -23,7 +23,31 @@
       "CapAmount",
       "Currency",
       "SettlementReference",
+      "Notes",
+      "DetentionTerms"
+    ]
+  },
+  "detentionTerms": {
+    "required": [
+      "GracePeriodMinutes",
+      "RateAmount",
+      "RateUnit"
+    ],
+    "optional": [
+      "BillingIncrementMinutes",
+      "RequiresDelayNotice",
+      "RequiresLocationEvidence",
+      "LocationEvidenceType",
       "Notes"
+    ],
+    "rateUnits": [
+      "Hour"
+    ],
+    "locationEvidenceTypes": [
+      "GPS",
+      "ELDPosition",
+      "GeofenceCheckIn",
+      "Other"
     ]
   },
   "pricingModes": [
@@ -57,6 +81,9 @@
     "reimbursableRequiresPayerPayee": true,
     "tbdRequiresPayerPayee": true,
     "evidenceTypeRequiredWhenEvidenceRequired": true,
+    "detentionTermsRequiredForDetentionType": true,
+    "detentionTermsOnlyAllowedForDetentionType": true,
+    "locationEvidenceTypeRequiredWhenLocationEvidenceRequired": true,
     "maxAmountNotRequired": true,
     "settlementExecutionOutOfScope": true
   },

--- a/conformance/accessorial_type_registry.v1.json
+++ b/conformance/accessorial_type_registry.v1.json
@@ -6,10 +6,10 @@
   "activeTypes": [
     "UnloadingFee",
     "OverweightPermit",
-    "EscortVehicle"
+    "EscortVehicle",
+    "Detention"
   ],
   "plannedTypes": [
-    "Detention",
     "Layover",
     "LumperFee"
   ],

--- a/docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md
+++ b/docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md
@@ -15,8 +15,9 @@ It does not run dispatch operations, document adjudication, or payment execution
 - `PayeeParty`
 - optional `CapAmount`
 - evidence intent (`EvidenceRequired`, `EvidenceType`)
-3. Carrier acceptance of these terms in booking negotiation.
-4. Execution report snapshot of the agreed commercial terms.
+3. Detention commercial policy terms as booking metadata (for example grace period, hourly amount, billing increment, and delay/location evidence intent).
+4. Carrier acceptance of these terms in booking negotiation.
+5. Execution report snapshot of the agreed commercial terms.
 
 ## Out of Scope (Protocol Core)
 Settlement and payment execution are out of scope for FAXP core.
@@ -37,6 +38,7 @@ Settlement and payment execution are out of scope for FAXP core.
 2. `PassThrough`, `Reimbursable`, and `TBD` require explicit payer/payee allocation.
 3. Terms are valid only as booking-plane contract metadata in FAXP core.
 4. Operational evidence handling is delegated to external systems (TMS, carrier portals, claims workflows).
+5. Detention evidence intent fields are commercial preconditions only; proof adjudication remains external.
 
 ## Future Expansion Policy
 Operations-plane messaging is a scope expansion track and must be introduced through a separate RFC/governance process (for example a future `FAXP-OPS` profile).

--- a/faxp_mvp_simulation.py
+++ b/faxp_mvp_simulation.py
@@ -1743,8 +1743,8 @@ ACCESSORIAL_TYPE_CATALOG = {
     "UnloadingFee": {"status": "active"},
     "OverweightPermit": {"status": "active"},
     "EscortVehicle": {"status": "active"},
+    "Detention": {"status": "active"},
     # Planned types are declared for roadmap visibility and future RFC-governed expansion.
-    "Detention": {"status": "planned"},
     "Layover": {"status": "planned"},
     "LumperFee": {"status": "planned"},
 }
@@ -1757,6 +1757,8 @@ PLANNED_ACCESSORIAL_TYPES = tuple(
 VALID_ACCESSORIAL_PARTIES = {"Broker", "Carrier", "Shipper", "Vendor", "Unknown"}
 VALID_ACCESSORIAL_EVIDENCE_TYPES = {"Receipt", "Permit", "EscortInvoice", "Other"}
 VALID_ACCESSORIAL_STATUSES = {"Pending", "Approved", "Rejected", "TBD"}
+VALID_DETENTION_RATE_UNITS = {"Hour"}
+VALID_DETENTION_LOCATION_EVIDENCE_TYPES = {"GPS", "ELDPosition", "GeofenceCheckIn", "Other"}
 FORBIDDEN_BIOMETRIC_FIELDS = {
     "faceimage",
     "selfieimage",
@@ -2062,6 +2064,12 @@ def _validate_accessorial_term(term, context):
     if term.get("EvidenceRequired") is True and "EvidenceType" not in term:
         raise ValueError(f"{context}.EvidenceType is required when EvidenceRequired is true.")
 
+    if term["Type"] == "Detention":
+        _require_fields(term, ["DetentionTerms"], context)
+        _validate_detention_terms(term["DetentionTerms"], f"{context}.DetentionTerms")
+    elif "DetentionTerms" in term:
+        raise ValueError(f"{context}.DetentionTerms is only allowed when Type is 'Detention'.")
+
     if "CapAmount" in term:
         value = term["CapAmount"]
         if not isinstance(value, (int, float)) or value < 0:
@@ -2074,6 +2082,49 @@ def _validate_accessorial_term(term, context):
         _bounded_string(term["SettlementReference"], f"{context}.SettlementReference")
     if "Notes" in term:
         _bounded_string(term["Notes"], f"{context}.Notes")
+
+
+def _validate_detention_terms(terms, context):
+    if not isinstance(terms, dict):
+        raise ValueError(f"{context} must be an object.")
+    _require_fields(terms, ["GracePeriodMinutes", "RateAmount", "RateUnit"], context)
+
+    grace_period = terms["GracePeriodMinutes"]
+    if not isinstance(grace_period, int) or grace_period < 0:
+        raise ValueError(f"{context}.GracePeriodMinutes must be a non-negative integer.")
+
+    rate_amount = terms["RateAmount"]
+    if not isinstance(rate_amount, (int, float)) or rate_amount <= 0:
+        raise ValueError(f"{context}.RateAmount must be a positive number.")
+
+    _bounded_string(terms["RateUnit"], f"{context}.RateUnit")
+    if terms["RateUnit"] not in VALID_DETENTION_RATE_UNITS:
+        raise ValueError(f"{context}.RateUnit must be one of {sorted(VALID_DETENTION_RATE_UNITS)}.")
+
+    if "BillingIncrementMinutes" in terms:
+        billing_increment = terms["BillingIncrementMinutes"]
+        if not isinstance(billing_increment, int) or billing_increment <= 0:
+            raise ValueError(f"{context}.BillingIncrementMinutes must be a positive integer.")
+
+    for field in ["RequiresDelayNotice", "RequiresLocationEvidence"]:
+        if field in terms and not isinstance(terms[field], bool):
+            raise ValueError(f"{context}.{field} must be boolean.")
+
+    if "LocationEvidenceType" in terms:
+        _bounded_string(terms["LocationEvidenceType"], f"{context}.LocationEvidenceType")
+        if terms["LocationEvidenceType"] not in VALID_DETENTION_LOCATION_EVIDENCE_TYPES:
+            raise ValueError(
+                f"{context}.LocationEvidenceType must be one of "
+                f"{sorted(VALID_DETENTION_LOCATION_EVIDENCE_TYPES)}."
+            )
+
+    if terms.get("RequiresLocationEvidence") is True and "LocationEvidenceType" not in terms:
+        raise ValueError(
+            f"{context}.LocationEvidenceType is required when RequiresLocationEvidence is true."
+        )
+
+    if "Notes" in terms:
+        _bounded_string(terms["Notes"], f"{context}.Notes")
 
 
 def _validate_accessorial_policy(policy, context):
@@ -3650,6 +3701,25 @@ class BrokerAgent:
                         "EvidenceType": "EscortInvoice",
                         "Currency": "USD",
                     },
+                    {
+                        "Type": "Detention",
+                        "PricingMode": "Reimbursable",
+                        "PayerParty": "Broker",
+                        "PayeeParty": "Carrier",
+                        "ApprovalRequired": True,
+                        "EvidenceRequired": False,
+                        "Currency": "USD",
+                        "DetentionTerms": {
+                            "GracePeriodMinutes": 120,
+                            "RateAmount": 25.0,
+                            "RateUnit": "Hour",
+                            "BillingIncrementMinutes": 60,
+                            "RequiresDelayNotice": True,
+                            "RequiresLocationEvidence": True,
+                            "LocationEvidenceType": "GPS",
+                            "Notes": "Delay notice and location evidence are commercial preconditions only.",
+                        },
+                    },
                 ],
             },
             # Charges are intentionally empty at booking time; they can be approved later.
@@ -4080,6 +4150,25 @@ class ShipperAgent:
                         "EvidenceRequired": True,
                         "EvidenceType": "EscortInvoice",
                         "Currency": "USD",
+                    },
+                    {
+                        "Type": "Detention",
+                        "PricingMode": "Reimbursable",
+                        "PayerParty": "Broker",
+                        "PayeeParty": "Carrier",
+                        "ApprovalRequired": True,
+                        "EvidenceRequired": False,
+                        "Currency": "USD",
+                        "DetentionTerms": {
+                            "GracePeriodMinutes": 120,
+                            "RateAmount": 25.0,
+                            "RateUnit": "Hour",
+                            "BillingIncrementMinutes": 60,
+                            "RequiresDelayNotice": True,
+                            "RequiresLocationEvidence": True,
+                            "LocationEvidenceType": "GPS",
+                            "Notes": "Delay notice and location evidence are commercial preconditions only.",
+                        },
                     },
                 ],
             },

--- a/tests/run_accessorial_terms.py
+++ b/tests/run_accessorial_terms.py
@@ -31,7 +31,7 @@ def _expect_validation_error(message_type: str, body: dict, text: str) -> None:
 
 def _base_accessorial_policy() -> dict:
     return {
-        "AllowedTypes": ["UnloadingFee", "OverweightPermit", "EscortVehicle"],
+        "AllowedTypes": ["UnloadingFee", "OverweightPermit", "EscortVehicle", "Detention"],
         "RequiresApproval": True,
         "MaxTotal": 300.0,
         "Currency": "USD",
@@ -66,6 +66,24 @@ def _base_accessorial_policy() -> dict:
                 "EvidenceRequired": True,
                 "EvidenceType": "EscortInvoice",
                 "Currency": "USD",
+            },
+            {
+                "Type": "Detention",
+                "PricingMode": "Reimbursable",
+                "PayerParty": "Broker",
+                "PayeeParty": "Carrier",
+                "ApprovalRequired": True,
+                "EvidenceRequired": False,
+                "Currency": "USD",
+                "DetentionTerms": {
+                    "GracePeriodMinutes": 120,
+                    "RateAmount": 25.0,
+                    "RateUnit": "Hour",
+                    "BillingIncrementMinutes": 60,
+                    "RequiresDelayNotice": True,
+                    "RequiresLocationEvidence": True,
+                    "LocationEvidenceType": "GPS",
+                },
             },
         ],
     }
@@ -119,11 +137,39 @@ def main() -> int:
         )
 
         bad_type = _base_accessorial_policy()
-        bad_type["Terms"][2]["Type"] = "Detention"
+        bad_type["Terms"][2]["Type"] = "UnknownType"
         _expect_validation_error(
             "NewLoad",
             {**new_load, "AccessorialPolicy": bad_type},
             "Type must be present in NewLoad.AccessorialPolicy.AllowedTypes",
+        )
+
+        missing_detention_terms = _base_accessorial_policy()
+        del missing_detention_terms["Terms"][3]["DetentionTerms"]
+        _expect_validation_error(
+            "NewLoad",
+            {**new_load, "AccessorialPolicy": missing_detention_terms},
+            "missing required fields",
+        )
+
+        invalid_detention_evidence = _base_accessorial_policy()
+        invalid_detention_evidence["Terms"][3]["DetentionTerms"]["LocationEvidenceType"] = "Camera"
+        _expect_validation_error(
+            "NewLoad",
+            {**new_load, "AccessorialPolicy": invalid_detention_evidence},
+            "LocationEvidenceType must be one of",
+        )
+
+        invalid_detention_attachment = _base_accessorial_policy()
+        invalid_detention_attachment["Terms"][0]["DetentionTerms"] = {
+            "GracePeriodMinutes": 120,
+            "RateAmount": 25.0,
+            "RateUnit": "Hour",
+        }
+        _expect_validation_error(
+            "NewLoad",
+            {**new_load, "AccessorialPolicy": invalid_detention_attachment},
+            "DetentionTerms is only allowed when Type is 'Detention'",
         )
 
         bid_request = {
@@ -132,7 +178,7 @@ def main() -> int:
             "AvailabilityDate": "2026-03-01",
             "AccessorialPolicyAcceptance": {
                 "Accepted": True,
-                "AllowedTypes": ["UnloadingFee", "OverweightPermit", "EscortVehicle"],
+                "AllowedTypes": ["UnloadingFee", "OverweightPermit", "EscortVehicle", "Detention"],
             },
         }
         validate_message_body("BidRequest", bid_request)
@@ -185,7 +231,7 @@ def main() -> int:
         bad_execution = {
             **execution_report,
             "Accessorials": [
-                {"Type": "Detention", "Amount": 80.0, "Currency": "USD", "Status": "Approved"}
+                {"Type": "Layover", "Amount": 80.0, "Currency": "USD", "Status": "Approved"}
             ],
         }
         _expect_validation_error(

--- a/tests/run_accessorial_terms_profile.py
+++ b/tests/run_accessorial_terms_profile.py
@@ -14,6 +14,8 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from faxp_mvp_simulation import (  # noqa: E402
+    VALID_DETENTION_LOCATION_EVIDENCE_TYPES,
+    VALID_DETENTION_RATE_UNITS,
     VALID_ACCESSORIAL_EVIDENCE_TYPES,
     VALID_ACCESSORIAL_PARTIES,
     VALID_ACCESSORIAL_PRICING_MODES,
@@ -51,6 +53,7 @@ def main() -> int:
         "pricingModes",
         "partyRoles",
         "evidenceTypes",
+        "detentionTerms",
         "entryStatuses",
         "normativeConstraints",
         "conformanceRequirements",
@@ -73,6 +76,26 @@ def main() -> int:
     _assert(
         {str(item) for item in term_fields.get("required") or []} == {"Type", "PricingMode"},
         "termFields.required must be Type and PricingMode",
+    )
+    _assert(
+        "DetentionTerms" in {str(item) for item in term_fields.get("optional") or []},
+        "termFields.optional must include DetentionTerms",
+    )
+
+    detention_terms = profile.get("detentionTerms") or {}
+    _assert(
+        {str(item) for item in detention_terms.get("required") or []}
+        == {"GracePeriodMinutes", "RateAmount", "RateUnit"},
+        "detentionTerms.required must be GracePeriodMinutes, RateAmount, and RateUnit",
+    )
+    _assert(
+        set(detention_terms.get("rateUnits") or []) == set(VALID_DETENTION_RATE_UNITS),
+        "detentionTerms.rateUnits must match VALID_DETENTION_RATE_UNITS",
+    )
+    _assert(
+        set(detention_terms.get("locationEvidenceTypes") or [])
+        == set(VALID_DETENTION_LOCATION_EVIDENCE_TYPES),
+        "detentionTerms.locationEvidenceTypes must match VALID_DETENTION_LOCATION_EVIDENCE_TYPES",
     )
 
     _assert(
@@ -99,6 +122,9 @@ def main() -> int:
         "reimbursableRequiresPayerPayee",
         "tbdRequiresPayerPayee",
         "evidenceTypeRequiredWhenEvidenceRequired",
+        "detentionTermsRequiredForDetentionType",
+        "detentionTermsOnlyAllowedForDetentionType",
+        "locationEvidenceTypeRequiredWhenLocationEvidenceRequired",
         "maxAmountNotRequired",
         "settlementExecutionOutOfScope",
     ]:


### PR DESCRIPTION
## Summary
This PR adds explicit booking-plane detention policy semantics to FAXP commercial terms.

### What changed
- Activated `Detention` as a canonical active accessorial type.
- Added strict `DetentionTerms` validation in runtime:
  - required: `GracePeriodMinutes`, `RateAmount`, `RateUnit`
  - optional: `BillingIncrementMinutes`, `RequiresDelayNotice`, `RequiresLocationEvidence`, `LocationEvidenceType`, `Notes`
  - enforced constraints for evidence-type coupling and type scoping.
- Updated default broker/shipper policies to include detention commercial terms.
- Updated conformance artifacts:
  - `conformance/accessorial_terms_profile.v1.json`
  - `conformance/accessorial_type_registry.v1.json`
- Extended tests for valid/invalid detention term cases.
- Updated governance docs to clarify detention is booking metadata only.

## Scope guardrail
No operations-plane behavior was added (no dispatch proof adjudication, no settlement/payment execution).

## Validation
- `python3 tests/run_accessorial_terms.py`
- `python3 tests/run_accessorial_terms_profile.py`
- `python3 tests/run_accessorial_type_registry.py`
- `python3 tests/run_booking_plane_commercial_terms_doc.py`
- `./.venv/bin/python tests/run_conformance_suite.py`
- `./.venv/bin/python tests/run_release_readiness.py`
