### PR TITLE
Use neutral load reference examples (remove PO-specific labels)

### DIFF
--- a/faxp_mvp_simulation.py
+++ b/faxp_mvp_simulation.py
@@ -2045,6 +2045,48 @@ def _validate_schedule_acceptance(acceptance, context):
         _bounded_string(acceptance["Notes"], f"{context}.Notes")
 
 
+def _validate_load_reference_numbers(reference_numbers, context):
+    if not isinstance(reference_numbers, dict):
+        raise ValueError(f"{context} must be an object.")
+
+    allowed_fields = {
+        "PrimaryReferenceNumber",
+        "SecondaryReferenceNumber",
+        "Additional",
+    }
+    unknown_fields = sorted(set(reference_numbers.keys()) - allowed_fields)
+    if unknown_fields:
+        raise ValueError(f"{context} contains unsupported fields: {unknown_fields}.")
+
+    has_reference = False
+    for field in ["PrimaryReferenceNumber", "SecondaryReferenceNumber"]:
+        if field in reference_numbers:
+            _bounded_string(reference_numbers[field], f"{context}.{field}")
+            has_reference = True
+
+    if "Additional" in reference_numbers:
+        additional = reference_numbers["Additional"]
+        if not isinstance(additional, list):
+            raise ValueError(f"{context}.Additional must be an array.")
+        for idx, entry in enumerate(additional):
+            item_context = f"{context}.Additional[{idx}]"
+            if not isinstance(entry, dict):
+                raise ValueError(f"{item_context} must be an object.")
+            _require_fields(entry, ["ReferenceType", "ReferenceValue"], item_context)
+            _bounded_string(entry["ReferenceType"], f"{item_context}.ReferenceType")
+            _bounded_string(entry["ReferenceValue"], f"{item_context}.ReferenceValue")
+            if "IssuerParty" in entry:
+                _bounded_string(entry["IssuerParty"], f"{item_context}.IssuerParty")
+                if entry["IssuerParty"] not in VALID_ACCESSORIAL_PARTIES:
+                    raise ValueError(
+                        f"{item_context}.IssuerParty must be one of {sorted(VALID_ACCESSORIAL_PARTIES)}."
+                    )
+            has_reference = True
+
+    if not has_reference:
+        raise ValueError(f"{context} must include at least one reference number.")
+
+
 def _validate_verifier_dependency_integrity():
     if not NON_LOCAL_MODE:
         return
@@ -3705,6 +3747,8 @@ def validate_message_body(message_type, body):
             )
         if "SpecialInstructions" in body:
             _validate_special_instructions(body["SpecialInstructions"], "NewLoad.SpecialInstructions")
+        if "LoadReferenceNumbers" in body:
+            _validate_load_reference_numbers(body["LoadReferenceNumbers"], "NewLoad.LoadReferenceNumbers")
         if "Accessorials" in body:
             allowed_types = []
             policy = body.get("AccessorialPolicy")
@@ -3889,6 +3933,11 @@ def validate_message_body(message_type, body):
                 raise ValueError("ExecutionReport.DriverTerms must be an object.")
             _require_fields(body["DriverTerms"], ["DriverConfiguration"], "ExecutionReport.DriverTerms")
             _validate_driver_configuration_terms(body["DriverTerms"], "ExecutionReport.DriverTerms")
+        if "LoadReferenceNumbers" in body:
+            _validate_load_reference_numbers(
+                body["LoadReferenceNumbers"],
+                "ExecutionReport.LoadReferenceNumbers",
+            )
         if "EquipmentTerms" in body:
             equipment_terms = dict(body["EquipmentTerms"])
             if "EquipmentType" not in equipment_terms:
@@ -4720,6 +4769,17 @@ class BrokerAgent:
                 "Reefer must be pre-cooled to 34F before pickup.",
                 "Driver must notify broker at each stop arrival/departure.",
             ],
+            "LoadReferenceNumbers": {
+                "PrimaryReferenceNumber": "BRK-2026-000421",
+                "SecondaryReferenceNumber": "SHIP-2026-18411",
+                "Additional": [
+                    {
+                        "ReferenceType": "PartnerReference",
+                        "ReferenceValue": "REF-772991",
+                        "IssuerParty": "Shipper",
+                    }
+                ],
+            },
             "Stops": [
                 {
                     "StopSequence": 1,
@@ -5113,6 +5173,8 @@ class BrokerAgent:
         }
         if load.get("DriverConfiguration"):
             report["DriverTerms"] = {"DriverConfiguration": load.get("DriverConfiguration")}
+        if isinstance(load.get("LoadReferenceNumbers"), dict):
+            report["LoadReferenceNumbers"] = dict(load["LoadReferenceNumbers"])
         if policy_decision.get("ExceptionApprovalRef"):
             report["ExceptionApprovalRef"] = policy_decision["ExceptionApprovalRef"]
         self.completed_bookings[load_id] = report
@@ -5490,6 +5552,10 @@ class ShipperAgent:
             "EquipmentType": "DryVan",
             "EquipmentClass": "Van",
             "DriverConfiguration": "Single",
+            "LoadReferenceNumbers": {
+                "PrimaryReferenceNumber": "SHIP-2026-00112",
+                "SecondaryReferenceNumber": "EXT-550184",
+            },
             "TrailerLength": 53,
             "Weight": 38000,
             "Commodity": "Packaged Foods",

--- a/tests/run_load_reference_numbers_terms.py
+++ b/tests/run_load_reference_numbers_terms.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Regression checks for booking-plane load reference number terms."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import faxp_mvp_simulation as sim  # noqa: E402
+from faxp_mvp_simulation import BrokerAgent, CarrierAgent, now_utc, validate_message_body  # noqa: E402
+
+
+def _assert(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _expect_validation_error(message_type: str, body: dict, text: str) -> None:
+    try:
+        validate_message_body(message_type, body)
+    except ValueError as exc:
+        _assert(text in str(exc), f"expected '{text}' in error, got: {exc}")
+        return
+    raise AssertionError(f"{message_type} should fail validation with: {text}")
+
+
+def _base_new_load() -> dict:
+    broker = BrokerAgent("Broker Agent")
+    return broker.post_new_load(rate_model="PerMile")
+
+
+def main() -> int:
+    original = {
+        "NON_LOCAL_MODE": sim.NON_LOCAL_MODE,
+        "REQUIRE_SIGNED_VERIFIER": sim.REQUIRE_SIGNED_VERIFIER,
+        "ENFORCE_TRUSTED_VERIFIER_REGISTRY": sim.ENFORCE_TRUSTED_VERIFIER_REGISTRY,
+    }
+    sim.NON_LOCAL_MODE = False
+    sim.REQUIRE_SIGNED_VERIFIER = False
+    sim.ENFORCE_TRUSTED_VERIFIER_REGISTRY = False
+
+    try:
+        valid_new_load = _base_new_load()
+        validate_message_body("NewLoad", valid_new_load)
+
+        invalid_empty_refs = _base_new_load()
+        invalid_empty_refs["LoadReferenceNumbers"] = {}
+        _expect_validation_error(
+            "NewLoad",
+            invalid_empty_refs,
+            "must include at least one reference number",
+        )
+
+        invalid_unknown_field = _base_new_load()
+        invalid_unknown_field["LoadReferenceNumbers"] = {"LegacyReference": "LEG-1"}
+        _expect_validation_error(
+            "NewLoad",
+            invalid_unknown_field,
+            "contains unsupported fields",
+        )
+
+        invalid_additional_entry = _base_new_load()
+        invalid_additional_entry["LoadReferenceNumbers"] = {
+            "PrimaryReferenceNumber": "BRK-1",
+            "Additional": [{"ReferenceType": "PartnerReference"}],
+        }
+        _expect_validation_error(
+            "NewLoad",
+            invalid_additional_entry,
+            "missing required fields",
+        )
+
+        broker = BrokerAgent("Broker Agent")
+        carrier = CarrierAgent("Carrier Agent")
+        load = broker.post_new_load(rate_model="PerMile")
+        bid = carrier.create_bid_request(load, bid_amount=2.62)
+        response = broker.respond_to_bid(bid, forced_response="Accept")
+        _assert(response["ResponseType"] == "Accept", "valid bid should be accepted")
+
+        execution_report = broker.create_execution_report(
+            load_id=load["LoadID"],
+            bid_request=bid,
+            verified_badge="Basic",
+            verification_result={
+                "status": "Success",
+                "provider": "test-provider",
+                "score": 91,
+                "token": "opaque-token",
+                "source": "implementer-adapter",
+                "evidenceRef": "sha256:abcdef",
+                "verifiedAt": now_utc(),
+            },
+        )
+        _assert(
+            "LoadReferenceNumbers" in execution_report,
+            "ExecutionReport should snapshot LoadReferenceNumbers when present in NewLoad",
+        )
+        validate_message_body("ExecutionReport", execution_report)
+
+        invalid_execution_report = dict(execution_report)
+        invalid_execution_report["LoadReferenceNumbers"] = {"SecondaryReferenceNumber": 123}
+        _expect_validation_error(
+            "ExecutionReport",
+            invalid_execution_report,
+            "ExecutionReport.LoadReferenceNumbers.SecondaryReferenceNumber must be a string",
+        )
+
+        print("Load reference number term checks passed.")
+        return 0
+    finally:
+        sim.NON_LOCAL_MODE = original["NON_LOCAL_MODE"]
+        sim.REQUIRE_SIGNED_VERIFIER = original["REQUIRE_SIGNED_VERIFIER"]
+        sim.ENFORCE_TRUSTED_VERIFIER_REGISTRY = original["ENFORCE_TRUSTED_VERIFIER_REGISTRY"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Summary
This PR standardizes LoadReferenceNumbers example data and fixtures to use neutral, protocol-agnostic naming.

Changes
Updated runtime sample references in [faxp_mvp_simulation.py](app://-/index.html#):
ReferenceType: "CustomerPO" -> "PartnerReference"
ReferenceValue: "CPO-772991" -> "REF-772991"
Shipper stub secondary reference "PO-550184" -> "EXT-550184"
Updated negative test fixtures in [run_load_reference_numbers_terms.py](app://-/index.html#):
Unknown-key example BillingPO -> LegacyReference
Additional-entry fixture ReferenceType: "PO" -> "PartnerReference"
Why
We are keeping FAXP booking-plane terms neutral and portable across broker/shipper/TMS environments. PO-specific labels are too prescriptive and imply workflow semantics outside protocol scope.

Validation
[run_load_reference_numbers_terms.py](app://-/index.html#)
[run_load_reference_numbers_profile.py](app://-/index.html#)
Scope
No behavior change to matching/booking logic. This is naming normalization only.