### PR TITLE
Add RFC for equipment taxonomy expansion and map S10/S11 roadmap links

### DIFF
--- a/docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md
+++ b/docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md
@@ -1,0 +1,106 @@
+# RFC: v0.3 Equipment Taxonomy Expansion
+
+## RFC Metadata
+- RFC ID: `rfc-v0.3-equipment-taxonomy-expansion`
+- Title: `Expand booking-plane equipment taxonomy for specialty trailers and dimensional compatibility`
+- Author(s): `FAXP Governance Working Group`
+- Status: `Draft`
+- Target Version: `v0.3.x`
+- Created: `2026-02-26`
+- Last Updated: `2026-02-26`
+
+## Summary
+Standardize expanded booking-plane equipment taxonomy semantics across `EquipmentType`, `EquipmentClass`, `EquipmentSubClass`, `EquipmentTags`, and trailer length ranges so specialty trailer compatibility can be negotiated consistently without adding operations-plane behavior.
+
+## Motivation
+Current equipment support covers common classes and core matching behavior, but adoption requires consistent handling for specialty trailer requests and dimensional constraints. This RFC formalizes vocabulary and compatibility rules so brokers, carriers, and builders can interoperate deterministically.
+
+## Scope Gate (Required)
+- Scope Classification: `In-Scope`
+- Protocol-Core Impacted Files:
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp_mvp_simulation.py`
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.schema.json`
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.v0.2.schema.json`
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/equipment_profile.v1.json`
+- Message Types Added/Changed:
+  - `NewLoad` (equipment term normalization/validation only)
+  - `LoadSearch` (equipment filter normalization/validation only)
+  - `NewTruck` (equipment term normalization/validation only)
+  - `TruckSearch` (equipment filter normalization/validation only)
+  - `BidRequest` (equipment acceptance normalization/validation only)
+  - `BidResponse` (existing mismatch counter reason code path only)
+  - `ExecutionReport` (equipment terms snapshot only)
+- Schema Fields Added/Changed:
+  - `EquipmentClass`
+  - `EquipmentSubClass`
+  - `EquipmentTags`
+  - `TrailerLengthMin`
+  - `TrailerLengthMax`
+  - `EquipmentSpecialDescription`
+
+### Required Checks
+- [x] This RFC stays within booking-plane protocol scope.
+- [x] No new dispatch-orchestration message or state model is introduced.
+- [x] No new tracking lifecycle model (telematics/POD/BOL custody) is introduced.
+- [x] No new settlement lifecycle model (invoice/payment/remittance/factoring) is introduced.
+- [x] If `Scope Expansion`, this RFC includes full security/compliance/interoperability/migration analysis and explicit approval request.
+
+## Detailed Design
+1. Preserve current canonical equipment dimensions:
+   - primary class (`EquipmentClass`)
+   - optional subclass (`EquipmentSubClass`)
+   - optional tags (`EquipmentTags`)
+2. Keep `EquipmentType` as a user-facing label while requiring deterministic class/subclass/tag normalization.
+3. Standardize dimensional compatibility semantics:
+   - `TrailerLengthMin` and `TrailerLengthMax` express a required range when size flexibility exists.
+   - a single `TrailerLength` with no range remains valid and is treated as strict length.
+4. Keep mismatch behavior deterministic:
+   - incompatibility may trigger `BidResponse.Counter` with `ReasonCode=EquipmentCompatibilityDispute`.
+5. Keep `Special` class support:
+   - `EquipmentSpecialDescription` is required for non-canonical/special requests.
+6. No new message types are introduced.
+
+## Security Considerations
+1. Canonical normalization reduces spoofing/ambiguity via inconsistent free-text equipment labels.
+2. Strict validation reduces manipulation risk from conflicting dimensional terms.
+3. Existing signature, replay, and TTL controls remain unchanged and continue to protect message integrity.
+
+## Compliance and Governance Considerations
+1. Keep taxonomy vendor-neutral and implementation-agnostic.
+2. Maintain conformance profile coverage for class/subclass/tag/range semantics.
+3. Keep operations activities (dispatch assignment, trailer dispatching, execution tracking) out of scope.
+
+## Backward Compatibility
+1. Existing loads using only `EquipmentType` remain valid.
+2. Existing `EquipmentClass`/`EquipmentSubClass`/`EquipmentTags` behavior remains compatible.
+3. Existing strict trailer length semantics remain valid; range semantics remain additive.
+
+## Test Plan
+1. Runtime tests:
+   - class/subclass/tag validation and alias normalization
+   - strict and range-based trailer length compatibility
+   - deterministic mismatch counter behavior
+2. Profile tests:
+   - equipment profile artifact alignment with runtime constants/contract
+3. Integration checks:
+   - load and truck flows preserve compatibility behavior in happy-path and mismatch-path scenarios
+
+## Rollout Plan
+1. Approve this RFC.
+2. Land incremental profile/runtime/schema updates with conformance gates.
+3. Keep release gating on equipment runtime + profile tests in CI.
+4. Publish compatibility notes in release notes for builders.
+
+## Alternatives Considered
+1. Leave equipment as free-text only: rejected due to interoperability drift.
+2. Add operations-plane dispatch asset model now: rejected as scope expansion.
+3. Split into per-equipment message types: rejected as unnecessary complexity.
+
+## Open Questions
+1. Should canonical equipment vocabulary be maintained as one profile artifact or split by region/market profile?
+2. Should future dimensional constraints include width/height in booking plane or remain deferred?
+
+## Approval
+- Maintainer Approval:
+- Governance Approval (if required):
+- Date:

--- a/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md
+++ b/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md
@@ -81,7 +81,7 @@ Purpose: Central place to capture commercial model requirements before implement
 
 4. Equipment taxonomy expansion (specialty trailers + dimensional constraints)
 - Target: `v0.3.x`
-- RFC: `TBD (new RFC required)`
+- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md`
 - Acceptance:
   - Trailer type vocabulary includes `Hopper`, `StepDeck`, and others.
   - Trailer size/length is normalized and validated by equipment type.

--- a/docs/roadmap/V0_3_0_RFC_BACKLOG.md
+++ b/docs/roadmap/V0_3_0_RFC_BACKLOG.md
@@ -66,6 +66,14 @@ Scope policy: Booking-plane and certification governance only.
 - Notes: No mandatory A2A/MCP runtime dependency in FAXP core.
 - Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-a2a-mcp-interop-maturity.md`
 
+7. `RFC-v0.3-equipment-taxonomy-expansion`
+- Goal: Standardize specialty trailer taxonomy and dimensional compatibility semantics for booking-plane matching.
+- Scope class: `In-Scope`
+- Status: `Draft` (Deferred to v0.3.x)
+- Target: `v0.3.x`
+- Notes: Keep dispatch assignment and operations lifecycle out of scope.
+- Draft file: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md`
+
 ## Deferred / Explicitly Out-of-Scope for v0.3.0 RFC Batch
 
 1. Dispatch operations model.

--- a/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md
+++ b/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md
@@ -97,7 +97,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S10: Trailer Size Match (`53'` vs `48'` Reefer)
 
 - Description: Load requires specific reefer trailer size.
-- RFC: `TBD (new RFC required)`
+- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md`
 - Target: `v0.3.x`
 - Expected outcome:
   - Equipment matching distinguishes size-sensitive requirements.
@@ -106,7 +106,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S11: Specialty Trailer Match (Hopper / StepDeck)
 
 - Description: Load requires non-standard trailer class.
-- RFC: `TBD (new RFC required)`
+- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md`
 - Target: `v0.3.x`
 - Expected outcome:
   - Specialty equipment taxonomy is structured and validated.


### PR DESCRIPTION
## Summary
Adds a formal RFC for booking-plane equipment taxonomy expansion and links existing roadmap/scenario items to that RFC.

## What changed
- Added `docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md`
- Updated `docs/roadmap/V0_3_0_SCENARIO_CATALOG.md`
  - S10 and S11 now reference the equipment taxonomy RFC (no longer TBD)
- Updated `docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md`
  - Equipment taxonomy expansion item now points to the RFC
- Updated `docs/roadmap/V0_3_0_RFC_BACKLOG.md`
  - Added `RFC-v0.3-equipment-taxonomy-expansion` entry

## Scope
Governance/planning only.
No runtime, schema, CI, or protocol message behavior changes in this PR.

## Why
Our process requires RFC acceptance before implementation. This PR unblocks future implementation of specialty trailer and dimensional compatibility work while keeping scope boundaries explicit.
