### PR TITLE
Expand equipment type alias normalization for specialty trailer vocabulary

### DIFF
--- a/faxp_mvp_simulation.py
+++ b/faxp_mvp_simulation.py
@@ -1568,6 +1568,10 @@ def _infer_equipment_class_from_type(equipment_type):
     source = str(equipment_type or "").strip().lower()
     if not source:
         return ""
+    normalized_source = _normalize_equipment_token(source)
+    aliased_class = EQUIPMENT_TYPE_CLASS_ALIASES.get(normalized_source, "")
+    if aliased_class:
+        return aliased_class
     direct_alias = _canonical_equipment_class(equipment_type)
     if direct_alias:
         return direct_alias
@@ -1589,6 +1593,8 @@ def _infer_equipment_class_from_type(equipment_type):
         return "Lowboy"
     if "removeable gooseneck" in source or "removable gooseneck" in source or " rgn" in source:
         return "RGN"
+    if "flabtbed" in source:
+        return "Flatbed"
     if "flatbed" in source:
         return "Flatbed"
     if "reefer" in source:
@@ -1614,6 +1620,10 @@ def _infer_equipment_class_from_type(equipment_type):
 
 def _infer_equipment_subclass_from_type(equipment_type):
     source = str(equipment_type or "").strip().lower()
+    normalized_source = _normalize_equipment_token(source)
+    aliased_subclass = EQUIPMENT_TYPE_SUBCLASS_ALIASES.get(normalized_source, "")
+    if aliased_subclass:
+        return aliased_subclass
     candidates = [
         ("conestoga", "Conestoga"),
         ("contestoga", "Conestoga"),
@@ -1626,6 +1636,7 @@ def _infer_equipment_subclass_from_type(equipment_type):
         ("roller bed", "RollerBed"),
         ("vented", "Vented"),
         ("insulated", "Insulated"),
+        ("insultated", "Insulated"),
         ("intermodal", "Intermodal"),
         ("air ride", "AirRide"),
         ("hazmat", "Hazmat"),
@@ -2778,6 +2789,101 @@ EQUIPMENT_TAG_ALIASES = {
     "doubletrailer": "DoubleTrailer",
     "triple": "TripleTrailer",
     "tripletrailer": "TripleTrailer",
+}
+EQUIPMENT_TYPE_CLASS_ALIASES = {
+    "dryvan": "Van",
+    "reefer": "Reefer",
+    "flatbed": "Flatbed",
+    "autocarrier": "AutoCarrier",
+    "btrain": "BTrain",
+    "conestoga": "Flatbed",
+    "container": "Container",
+    "containerinsulated": "Container",
+    "containerinsultated": "Container",
+    "containerrefrigerated": "Container",
+    "conveyor": "Conveyor",
+    "doubledrop": "DoubleDrop",
+    "dropdecklandoll": "StepDeck",
+    "dumptrailer": "DumpTrailer",
+    "flatbedairride": "Flatbed",
+    "flatbedconestoga": "Flatbed",
+    "flatbedcontestoga": "Flatbed",
+    "flatbeddouble": "Flatbed",
+    "flatbedhazmat": "Flatbed",
+    "flatbedhotshot": "Flatbed",
+    "flatbedmaxi": "Flatbed",
+    "flatbedoverdimension": "Flatbed",
+    "flabtbedoverdimension": "Flatbed",
+    "hopperbottom": "HopperBottom",
+    "lowboy": "Lowboy",
+    "lowboyoverdimension": "Lowboy",
+    "movingvan": "MovingVan",
+    "pneumatic": "Pneumatic",
+    "poweronly": "PowerOnly",
+    "reeferairride": "Reefer",
+    "reeferdouble": "Reefer",
+    "reeferhazmat": "Reefer",
+    "reeferintermodal": "Reefer",
+    "removeablegooseneck": "RGN",
+    "removablegooseneck": "RGN",
+    "stepdeck": "StepDeck",
+    "stepdeckconestoga": "StepDeck",
+    "straightboxtruck": "StraightBoxTruck",
+    "stretchtrailer": "Flatbed",
+    "tankeraluminum": "Tanker",
+    "tankerintermodal": "Tanker",
+    "tankersteel": "Tanker",
+    "vanairride": "Van",
+    "vanconestoga": "Van",
+    "vanhazmat": "Van",
+    "vanhotshot": "Van",
+    "vaninsulated": "Van",
+    "vanintermodal": "Van",
+    "vanliftgate": "Van",
+    "vanopentop": "Van",
+    "vanrollerbed": "Van",
+    "vantriple": "Van",
+    "vanvented": "Van",
+    "sprintervan": "SprinterVan",
+    "sprintervanhazmat": "SprinterVan",
+}
+EQUIPMENT_TYPE_SUBCLASS_ALIASES = {
+    "conestoga": "Conestoga",
+    "containerinsulated": "Insulated",
+    "containerinsultated": "Insulated",
+    "containerrefrigerated": "Insulated",
+    "dropdecklandoll": "Landoll",
+    "flatbedairride": "AirRide",
+    "flatbedconestoga": "Conestoga",
+    "flatbedcontestoga": "Conestoga",
+    "flatbeddouble": "Double",
+    "flatbedhazmat": "Hazmat",
+    "flatbedhotshot": "Hotshot",
+    "flatbedmaxi": "Maxi",
+    "flatbedoverdimension": "OverDimension",
+    "flabtbedoverdimension": "OverDimension",
+    "lowboyoverdimension": "OverDimension",
+    "reeferairride": "AirRide",
+    "reeferdouble": "Double",
+    "reeferhazmat": "Hazmat",
+    "reeferintermodal": "Intermodal",
+    "stepdeckconestoga": "Conestoga",
+    "stretchtrailer": "Stretch",
+    "tankeraluminum": "Aluminum",
+    "tankerintermodal": "Intermodal",
+    "tankersteel": "Steel",
+    "vanairride": "AirRide",
+    "vanconestoga": "Conestoga",
+    "vanhazmat": "Hazmat",
+    "vanhotshot": "Hotshot",
+    "vaninsulated": "Insulated",
+    "vanintermodal": "Intermodal",
+    "vanliftgate": "LiftGate",
+    "vanopentop": "OpenTop",
+    "vanrollerbed": "RollerBed",
+    "vantriple": "Triple",
+    "vanvented": "Vented",
+    "sprintervanhazmat": "Hazmat",
 }
 FORBIDDEN_BIOMETRIC_FIELDS = {
     "faceimage",

--- a/tests/run_equipment_terms.py
+++ b/tests/run_equipment_terms.py
@@ -53,8 +53,82 @@ def _base_new_load() -> dict:
     }
 
 
+def _alias_normalization_matrix() -> list[tuple[str, str, str]]:
+    return [
+        ("Dry Van", "Van", ""),
+        ("Reefer", "Reefer", ""),
+        ("Flatbed", "Flatbed", ""),
+        ("Auto Carrier", "AutoCarrier", ""),
+        ("B-Train", "BTrain", ""),
+        ("Conestoga", "Flatbed", "Conestoga"),
+        ("Container", "Container", ""),
+        ("Container - Insultated", "Container", "Insulated"),
+        ("Container - Refrigerated", "Container", "Insulated"),
+        ("Conveyor", "Conveyor", ""),
+        ("Double Drop", "DoubleDrop", "Double"),
+        ("Drop Deck Landoll", "StepDeck", "Landoll"),
+        ("Dump Trailer", "DumpTrailer", ""),
+        ("Flatbed - Air Ride", "Flatbed", "AirRide"),
+        ("Flatbed - Contestoga", "Flatbed", "Conestoga"),
+        ("Flatbed - Double", "Flatbed", "Double"),
+        ("Flatbed - Hazmat", "Flatbed", "Hazmat"),
+        ("Flatbed - Hotshot", "Flatbed", "Hotshot"),
+        ("Flatbed - Maxi", "Flatbed", "Maxi"),
+        ("Flabtbed - Over Dimension", "Flatbed", "OverDimension"),
+        ("Hopper Bottom", "HopperBottom", ""),
+        ("Lowboy", "Lowboy", ""),
+        ("RGN", "RGN", ""),
+        ("Lowboy - Over Dimension", "Lowboy", "OverDimension"),
+        ("Moving Van", "MovingVan", ""),
+        ("Pneumatic", "Pneumatic", ""),
+        ("Power Only", "PowerOnly", ""),
+        ("Reefer - Air Ride", "Reefer", "AirRide"),
+        ("Reefer - Double", "Reefer", "Double"),
+        ("Reefer - Hazmat", "Reefer", "Hazmat"),
+        ("Reefer - Intermodal", "Reefer", "Intermodal"),
+        ("Removeable Gooseneck", "RGN", ""),
+        ("Stepdeck", "StepDeck", ""),
+        ("Stepdeck - Conestoga", "StepDeck", "Conestoga"),
+        ("Straight Box Truck", "StraightBoxTruck", ""),
+        ("Stretch Trailer", "Flatbed", "Stretch"),
+        ("Tanker - Aluminum", "Tanker", "Aluminum"),
+        ("Tanker - Intermodal", "Tanker", "Intermodal"),
+        ("Tanker - Steel", "Tanker", "Steel"),
+        ("Van - Air Ride", "Van", "AirRide"),
+        ("Van - Conestoga", "Van", "Conestoga"),
+        ("Van - Hazmat", "Van", "Hazmat"),
+        ("Van - Hotshot", "Van", "Hotshot"),
+        ("Van - Insulated", "Van", "Insulated"),
+        ("Van - Intermodal", "Van", "Intermodal"),
+        ("Van - Lift Gate", "Van", "LiftGate"),
+        ("Van - Open Top", "Van", "OpenTop"),
+        ("Van - Roller Bed", "Van", "RollerBed"),
+        ("Van - Triple", "Van", "Triple"),
+        ("Van - Vented", "Van", "Vented"),
+        ("Sprinter Van", "SprinterVan", ""),
+        ("Sprinter Van - Hazmat", "SprinterVan", "Hazmat"),
+    ]
+
+
 def main() -> int:
     validate_message_body("NewLoad", _base_new_load())
+
+    for equipment_type, expected_class, expected_subclass in _alias_normalization_matrix():
+        alias_load = _base_new_load()
+        alias_load["EquipmentType"] = equipment_type
+        alias_load.pop("EquipmentClass", None)
+        alias_load.pop("EquipmentSubClass", None)
+        alias_load.pop("EquipmentTags", None)
+        validate_message_body("NewLoad", alias_load)
+        _assert(
+            alias_load["EquipmentClass"] == expected_class,
+            f"{equipment_type}: expected EquipmentClass={expected_class}, got {alias_load['EquipmentClass']}",
+        )
+        actual_subclass = alias_load.get("EquipmentSubClass", "")
+        _assert(
+            actual_subclass == expected_subclass,
+            f"{equipment_type}: expected EquipmentSubClass={expected_subclass}, got {actual_subclass}",
+        )
 
     special_missing_desc = _base_new_load()
     special_missing_desc["EquipmentClass"] = "Special"


### PR DESCRIPTION
## Summary
Expands `EquipmentType` alias normalization coverage for specialty trailer terms and typo variants while preserving existing matching semantics.

## Changes
- Added explicit alias maps in runtime:
  - `EQUIPMENT_TYPE_CLASS_ALIASES`
  - `EQUIPMENT_TYPE_SUBCLASS_ALIASES`
- Updated inference flow to resolve class/subclass from normalized alias before fallback heuristics.
- Added typo tolerance:
  - `Container - Insultated` -> `Insulated`
  - `Flabtbed - Over Dimension` -> `Flatbed` + `OverDimension`
- Added matrix regression coverage in `tests/run_equipment_terms.py` for specialty trailer names and variants.

## Scope
Booking-plane equipment normalization only.  
No new message types, no operations-plane expansion, no dispatch/payment behavior changes.

## Validation
- `./.venv/bin/python tests/run_equipment_terms.py`
- `./.venv/bin/python tests/run_equipment_profile.py`
- `./.venv/bin/python tests/run_conformance_suite.py`
