### PR TITLE
Harden equipment tag inference from canonical subclass and normalized aliases

### DIFF
--- a/faxp_mvp_simulation.py
+++ b/faxp_mvp_simulation.py
@@ -1654,18 +1654,25 @@ def _infer_equipment_subclass_from_type(equipment_type):
 
 def _infer_equipment_tags_from_type(equipment_type):
     source = str(equipment_type or "").strip().lower()
+    normalized_source = _normalize_equipment_token(source)
     tags = set()
-    if "air ride" in source:
+
+    subclass_value = _infer_equipment_subclass_from_type(equipment_type)
+    subclass_tag = EQUIPMENT_TAGS_BY_SUBCLASS.get(subclass_value, "")
+    if subclass_tag:
+        tags.add(subclass_tag)
+
+    if "airride" in normalized_source:
         tags.add("AirRide")
-    if "hazmat" in source:
+    if "hazmat" in normalized_source:
         tags.add("HazmatCapable")
-    if "intermodal" in source:
+    if "intermodal" in normalized_source:
         tags.add("Intermodal")
-    if "over dimension" in source:
+    if "overdimension" in normalized_source:
         tags.add("OverDimensionCapable")
-    if "double" in source:
+    if "double" in normalized_source:
         tags.add("DoubleTrailer")
-    if "triple" in source:
+    if "triple" in normalized_source:
         tags.add("TripleTrailer")
     return sorted(tags)
 
@@ -2789,6 +2796,14 @@ EQUIPMENT_TAG_ALIASES = {
     "doubletrailer": "DoubleTrailer",
     "triple": "TripleTrailer",
     "tripletrailer": "TripleTrailer",
+}
+EQUIPMENT_TAGS_BY_SUBCLASS = {
+    "AirRide": "AirRide",
+    "Hazmat": "HazmatCapable",
+    "Intermodal": "Intermodal",
+    "OverDimension": "OverDimensionCapable",
+    "Double": "DoubleTrailer",
+    "Triple": "TripleTrailer",
 }
 EQUIPMENT_TYPE_CLASS_ALIASES = {
     "dryvan": "Van",

--- a/tests/run_equipment_terms.py
+++ b/tests/run_equipment_terms.py
@@ -110,6 +110,17 @@ def _alias_normalization_matrix() -> list[tuple[str, str, str]]:
     ]
 
 
+def _alias_tag_inference_matrix() -> list[tuple[str, list[str]]]:
+    return [
+        ("vanhazmat", ["HazmatCapable"]),
+        ("reeferintermodal", ["Intermodal"]),
+        ("flatbedairride", ["AirRide"]),
+        ("flatbeddouble", ["DoubleTrailer"]),
+        ("vantriple", ["TripleTrailer"]),
+        ("flabtbedoverdimension", ["OverDimensionCapable"]),
+    ]
+
+
 def main() -> int:
     validate_message_body("NewLoad", _base_new_load())
 
@@ -128,6 +139,19 @@ def main() -> int:
         _assert(
             actual_subclass == expected_subclass,
             f"{equipment_type}: expected EquipmentSubClass={expected_subclass}, got {actual_subclass}",
+        )
+
+    for equipment_type, expected_tags in _alias_tag_inference_matrix():
+        alias_load = _base_new_load()
+        alias_load["EquipmentType"] = equipment_type
+        alias_load.pop("EquipmentClass", None)
+        alias_load.pop("EquipmentSubClass", None)
+        alias_load.pop("EquipmentTags", None)
+        validate_message_body("NewLoad", alias_load)
+        actual_tags = sorted(alias_load.get("EquipmentTags") or [])
+        _assert(
+            actual_tags == sorted(expected_tags),
+            f"{equipment_type}: expected EquipmentTags={sorted(expected_tags)}, got {actual_tags}",
         )
 
     special_missing_desc = _base_new_load()


### PR DESCRIPTION
## Summary
Hardens booking-plane equipment tag inference so specialty/no-space aliases resolve deterministically.

## Changes
- Added `EQUIPMENT_TAGS_BY_SUBCLASS` in runtime.
- Updated `_infer_equipment_tags_from_type()` to:
  - infer tags from canonical subclass output
  - use normalized token parsing (`airride`, `overdimension`, etc.) for alias robustness
- Added regression matrix for no-space alias forms in `tests/run_equipment_terms.py`:
  - `vanhazmat`
  - `reeferintermodal`
  - `flatbedairride`
  - `flatbeddouble`
  - `vantriple`
  - `flabtbedoverdimension`

## Scope
Runtime normalization hardening only.
No new message types, no scope expansion, no dispatch/payment behavior changes.

## Validation
- `./.venv/bin/python tests/run_equipment_terms.py`
- `./.venv/bin/python tests/run_equipment_profile.py`
- `./.venv/bin/python tests/run_conformance_suite.py`
- `./.venv/bin/python -m py_compile faxp_mvp_simulation.py tests/run_equipment_terms.py`
