### PR TITLE
Enforce version-bump policy for equipment alias coverage profile

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -29,6 +29,7 @@ This folder defines machine-readable artifacts for implementer-hosted adapters:
 - `load_reference_numbers_profile.v1.json`: canonical booking-plane external load reference metadata profile.
 - `equipment_profile.v1.json`: canonical booking-plane equipment taxonomy compatibility profile (includes alias normalization and subclass-driven tag inference constraints).
 - `equipment_type_alias_coverage.v1.json`: canonical booking-plane EquipmentType alias coverage map for class/subclass normalization.
+  - Includes `changePolicy` guardrails requiring profile revision + version bump when alias maps change.
 - `registry_update.schema.json`: schema for registry operations request payloads.
 - `registry_update.sample.json`: sample registry operations request with upsert/revoke/rollback.
 - `registry_update.sample.audit.log`: sample audit log for registry operations.

--- a/conformance/equipment_type_alias_coverage.v1.json
+++ b/conformance/equipment_type_alias_coverage.v1.json
@@ -103,6 +103,12 @@
     "flatbedcontestoga",
     "flabtbedoverdimension"
   ],
+  "changePolicy": {
+    "requireProfileUpdateBeforeRuntimeUse": true,
+    "requireVersionBumpOnAliasMapChange": true,
+    "lockedProfileMajor": 1,
+    "scopeNote": "EquipmentType alias map changes require profile revision + conformance updates under booking-plane scope guardrails."
+  },
   "conformanceRequirements": {
     "requiredTests": [
       "tests/run_equipment_type_alias_coverage.py"

--- a/tests/run_equipment_type_alias_coverage.py
+++ b/tests/run_equipment_type_alias_coverage.py
@@ -56,6 +56,7 @@ def main() -> int:
         "classAliasMap",
         "subclassAliasMap",
         "requiredTypoAliases",
+        "changePolicy",
         "conformanceRequirements",
     ]:
         _assert(field in profile, f"equipment type alias profile missing field: {field}")
@@ -97,6 +98,26 @@ def main() -> int:
             alias in class_alias_map or alias in subclass_alias_map,
             f"required typo alias missing from both maps: {alias}",
         )
+
+    change_policy = profile.get("changePolicy") or {}
+    _assert(
+        change_policy.get("requireProfileUpdateBeforeRuntimeUse") is True,
+        "changePolicy.requireProfileUpdateBeforeRuntimeUse must be true",
+    )
+    _assert(
+        change_policy.get("requireVersionBumpOnAliasMapChange") is True,
+        "changePolicy.requireVersionBumpOnAliasMapChange must be true",
+    )
+    _assert(
+        int(change_policy.get("lockedProfileMajor", 0)) == 1,
+        "changePolicy.lockedProfileMajor must equal 1",
+    )
+    profile_version = str(profile.get("profileVersion") or "").strip()
+    _assert(profile_version.startswith("1."), "profileVersion must remain in major version 1 for v1 artifact")
+    _assert(
+        isinstance(change_policy.get("scopeNote"), str) and change_policy.get("scopeNote").strip(),
+        "changePolicy.scopeNote must be a non-empty string",
+    )
 
     conformance_requirements = profile.get("conformanceRequirements") or {}
     required_tests = [str(item) for item in conformance_requirements.get("requiredTests") or []]


### PR DESCRIPTION
## Summary
Adds explicit versioning policy controls for the EquipmentType alias coverage artifact and enforces them in conformance tests.

## Changes
- Updated `conformance/equipment_type_alias_coverage.v1.json` with `changePolicy`:
  - `requireProfileUpdateBeforeRuntimeUse`
  - `requireVersionBumpOnAliasMapChange`
  - `lockedProfileMajor`
  - `scopeNote`
- Updated `tests/run_equipment_type_alias_coverage.py` to enforce policy contract and major-version lock for the v1 artifact.
- Updated `conformance/README.md` to document the version-bump guardrail.

## Why
Prevents silent alias-map drift and establishes explicit profile revision discipline for future `v1.1+` and major-version transitions.

## Validation
- `./.venv/bin/python tests/run_equipment_type_alias_coverage.py`
- `./.venv/bin/python tests/run_conformance_suite.py`
- `./.venv/bin/python tests/run_governance_index.py`
- `./.venv/bin/python tests/run_release_readiness.py`
