### PR TITLE
LaneMinimum RFC and wire v0.3 roadmap + scenarios

### DIFF
--- a/docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md
+++ b/docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md
@@ -1,0 +1,113 @@
+# RFC: v0.3 Rate Model Expansion (PerHour + LaneMinimum)
+
+## RFC Metadata
+- RFC ID: `rfc-v0.3-rate-model-hourly-lane-minimum`
+- Title: `Add booking-plane PerHour and LaneMinimum rate models`
+- Author(s): `FAXP Governance Working Group`
+- Status: `Draft`
+- Target Version: `v0.3.x`
+- Created: `2026-02-27`
+- Last Updated: `2026-02-27`
+
+## Summary
+Add two booking-plane commercial rate models, `PerHour` and `LaneMinimum`, with deterministic validation and execution-report normalization while preserving backward compatibility for existing rate models.
+
+## Motivation
+Current FAXP booking-plane support covers `PerMile`, `Flat`, `PerPallet`, and `CWT`. Real broker-carrier negotiations also use:
+1. `PerHour` (time-based pricing, often for local/short-haul and specialized handling windows).
+2. `LaneMinimum` (lane floor/guarantee semantics where a minimum total applies even if computed variable components are lower).
+
+Adding these models improves practical coverage without expanding into dispatch operations or settlement workflows.
+
+## Scope Gate (Required)
+- Scope Classification: `In-Scope`
+- Protocol-Core Impacted Files:
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp_mvp_simulation.py`
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.schema.json`
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.v0.2.schema.json`
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/rate_model_profile.v1.json` (or version bump successor)
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/streamlit_app.py`
+- Message Types Added/Changed:
+  - `NewLoad` (rate object extension only)
+  - `LoadSearch` (rate filter extension only)
+  - `BidRequest` (rate object extension only)
+  - `BidResponse` (counter-rate extension only)
+  - `ExecutionReport` (agreed-rate extension only)
+- Schema Fields Added/Changed:
+  - `Rate.RateModel` enum additions: `PerHour`, `LaneMinimum`
+  - model-specific required fields in `Rate` extension fields (for example `Hours`, `LaneMinimumAmount`)
+
+### Required Checks
+- [x] This RFC stays within booking-plane protocol scope.
+- [x] No new dispatch-orchestration message or state model is introduced.
+- [x] No new tracking lifecycle model (telematics/POD/BOL custody) is introduced.
+- [x] No new settlement lifecycle model (invoice/payment/remittance/factoring) is introduced.
+- [x] If `Scope Expansion`, this RFC includes full security/compliance/interoperability/migration analysis and explicit approval request.
+
+## Detailed Design
+1. Add `PerHour` model semantics:
+   - `Rate.Amount` is interpreted as currency per hour.
+   - `Rate.UnitBasis` must be `hour`.
+   - `Rate.Quantity` or `Rate.Hours` (final naming to be confirmed at implementation) must be present for deterministic total.
+2. Add `LaneMinimum` model semantics:
+   - `Rate.Amount` is interpreted as minimum total lane amount.
+   - If rate components are present, final agreed charge is `max(computed_components_total, lane_minimum_amount)`.
+   - `Rate.UnitBasis` may be `lane`.
+3. Preserve current rate component behavior:
+   - `LineHaulAmount` + optional `FuelSurchargeAmount` / `FuelSurchargePercent` remain valid where compatible.
+4. Keep fail-closed behavior:
+   - Unknown/unsupported model fails validation.
+   - Required model-specific fields missing -> validation fail.
+5. Maintain deterministic execution output:
+   - `ExecutionReport.AgreedRate` must preserve the model and fields needed to reconstruct pricing semantics.
+
+## Security Considerations
+1. Strict model-specific field requirements prevent semantic ambiguity attacks.
+2. Deterministic normalization prevents hidden arithmetic drift between agents.
+3. Existing envelope signatures, nonce, replay, and TTL remain unchanged and required.
+
+## Compliance and Governance Considerations
+1. Provider-neutral commercial model support only; no oracle/provider dependency in core.
+2. Conformance profile and tests must be updated before runtime activation.
+3. Streamlit/demo controls must not bypass validation and fail-closed requirements.
+
+## Backward Compatibility
+1. Existing `PerMile`, `Flat`, `PerPallet`, and `CWT` payloads remain valid.
+2. Agents that do not support the new models must fail closed with explicit reason.
+3. Version negotiation behavior remains governed by protocol compatibility profile.
+
+## Test Plan
+1. Unit/schema tests:
+   - valid/invalid vectors for `PerHour` and `LaneMinimum`.
+   - missing required field failures.
+   - unit-basis mismatch failures.
+2. Integration tests:
+   - broker->carrier and carrier->broker happy paths with each new model.
+   - counter/reject semantics preserved.
+3. Regression tests:
+   - no behavior change for existing models and extension fields.
+4. Conformance updates:
+   - update/add rate model profile artifact and signature checks.
+   - update release readiness/governance index mappings.
+
+## Rollout Plan
+1. Approve RFC.
+2. Land conformance artifact + tests first.
+3. Land runtime/schema changes behind current fail-closed behavior.
+4. Update Streamlit controls and validation messaging.
+5. Include in next RC and perform soak window.
+
+## Alternatives Considered
+1. Defer all new models to post-v0.3: rejected due to immediate commercial coverage gaps.
+2. Implement ad-hoc free-form model strings: rejected due to interoperability risk.
+3. Expand directly into settlement semantics: rejected as out of scope.
+
+## Open Questions
+1. Final field naming for time quantity (`Hours` vs `Quantity` + `UnitBasis=hour`).
+2. Whether `LaneMinimum` should require components or allow minimum-only contract form.
+3. Whether model-specific rounding rules should be protocol-level or profile-level.
+
+## Approval
+- Maintainer Approval:
+- Governance Approval (if required):
+- Date:

--- a/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md
+++ b/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md
@@ -106,8 +106,8 @@ Purpose: Central place to capture commercial model requirements before implement
 ### D) Future Commercial Scenarios
 
 1. Additional rate structures (hourly, lane-minimums, tiered pricing)
-- Target: `deferred`
-- RFC: `TBD`
+- Target: `v0.3.x`
+- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md`
 - Acceptance:
   - Added only via RFC with compatibility plan.
 

--- a/docs/roadmap/V0_3_0_RFC_BACKLOG.md
+++ b/docs/roadmap/V0_3_0_RFC_BACKLOG.md
@@ -74,6 +74,14 @@ Scope policy: Booking-plane and certification governance only.
 - Notes: Keep dispatch assignment and operations lifecycle out of scope.
 - Draft file: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md`
 
+8. `RFC-v0.3-rate-model-hourly-lane-minimum`
+- Goal: Add booking-plane `PerHour` and `LaneMinimum` rate models with deterministic validation and execution normalization.
+- Scope class: `In-Scope`
+- Status: `Draft` (Deferred to v0.3.x)
+- Target: `v0.3.x`
+- Notes: Keep implementation strictly booking-plane and fail closed for unsupported model fields.
+- Draft file: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md`
+
 ## Deferred / Explicitly Out-of-Scope for v0.3.0 RFC Batch
 
 1. Dispatch operations model.

--- a/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md
+++ b/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md
@@ -132,6 +132,26 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
   - Additional typed references support partner-specific identifiers without schema churn.
   - `ExecutionReport` preserves references for downstream TMS/document handoff.
 
+### S14: PerHour Negotiation for Dwell/Local Service
+
+- Description: Broker and carrier negotiate a `PerHour` booking-plane rate with explicit hours basis for a local or delay-sensitive load.
+- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md`
+- Target: `v0.3.x`
+- Expected outcome:
+  - `RateModel=PerHour` validates model-specific fields and unit basis deterministically.
+  - Counter path preserves reason codes and does not break existing `PerMile`/`Flat` behavior.
+  - `ExecutionReport` preserves time-based agreed-rate semantics for downstream handoff.
+
+### S15: LaneMinimum Commercial Floor Contract
+
+- Description: Carrier and broker negotiate a lane floor where `LaneMinimum` applies when computed components fall below a minimum total.
+- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md`
+- Target: `v0.3.x`
+- Expected outcome:
+  - `RateModel=LaneMinimum` validates required minimum semantics and fails closed when incomplete.
+  - Final agreed-rate normalization remains auditable and deterministic in `ExecutionReport`.
+  - Backward compatibility is preserved for existing rate models and profiles.
+
 ## Scenario Expansion Policy
 
 1. New scenario proposals must be added here first.


### PR DESCRIPTION
## Summary
- adds draft RFC for booking-plane rate model expansion:
  - `PerHour`
  - `LaneMinimum`
- wires commercial backlog item "Additional rate structures" to the new RFC
- adds RFC backlog entry for `RFC-v0.3-rate-model-hourly-lane-minimum`
- adds scenario mappings:
  - `S14` PerHour negotiation
  - `S15` LaneMinimum floor contract

## Scope
- planning/governance/docs only
- no runtime, schema, or Streamlit behavior changes

## Files
- docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md
- docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md
- docs/roadmap/V0_3_0_RFC_BACKLOG.md
- docs/roadmap/V0_3_0_SCENARIO_CATALOG.md
