### PR TITLE
Add booking-plane accessorial lifecycle RFC and roadmap/scenario wiring

### DIFF
--- a/docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md
+++ b/docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md
@@ -1,0 +1,107 @@
+# RFC: v0.3 Accessorial Lifecycle (Booking-Plane Contract Only)
+
+## RFC Metadata
+- RFC ID: `rfc-v0.3-accessorial-lifecycle-booking-plane`
+- Title: `Standardize booking-plane accessorial lifecycle terms and decision states`
+- Author(s): `FAXP Governance Working Group`
+- Status: `Draft`
+- Target Version: `v0.3.x`
+- Created: `2026-02-27`
+- Last Updated: `2026-02-27`
+
+## Summary
+Define a consistent booking-plane contract for accessorials so parties can negotiate expected charges, payer responsibility, and evidence requirements at booking time without expanding FAXP into dispatch execution or settlement workflows.
+
+## Motivation
+Accessorial disputes are a common source of friction and manual rework. Current behavior supports basic policy/cap concepts but lacks a complete lifecycle contract for:
+1. upfront declared accessorial terms,
+2. responsibility assignment (`PayerParty` / `PayeeParty`),
+3. post-booking claim states and required evidence references.
+
+This RFC closes that gap while preserving the scope boundary: FAXP standardizes booking-time terms and message semantics, not payment processing.
+
+## Scope Gate (Required)
+- Scope Classification: `In-Scope`
+- Protocol-Core Impacted Files:
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp_mvp_simulation.py`
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.schema.json`
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.v0.2.schema.json`
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/streamlit_app.py`
+  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/` (new or updated profile artifact)
+- Message Types Added/Changed:
+  - `NewLoad` (accessorial contract terms extension only)
+  - `BidRequest` (accessorial acceptance/counter semantics extension only)
+  - `BidResponse` (counter and reason semantics extension only)
+  - `ExecutionReport` (booking snapshot of agreed accessorial framework only)
+- Schema Fields Added/Changed:
+  - Structured accessorial term fields for booking-time agreement.
+  - Optional claim-reference structure for post-booking evidence linkage (IDs/URIs/hashes only, no document custody model).
+
+### Required Checks
+- [x] This RFC stays within booking-plane protocol scope.
+- [x] No new dispatch-orchestration message or state model is introduced.
+- [x] No new tracking lifecycle model (telematics/POD/BOL custody) is introduced.
+- [x] No new settlement lifecycle model (invoice/payment/remittance/factoring) is introduced.
+- [x] If `Scope Expansion`, this RFC includes full security/compliance/interoperability/migration analysis and explicit approval request.
+
+## Detailed Design
+1. Booking-time accessorial terms become explicit contract objects:
+   - `AccessorialType` (canonical registry value),
+   - `PricingMode` (fixed, per-hour, per-event, etc.),
+   - `PayerParty`, `PayeeParty`,
+   - optional policy controls (`PreApprovalRequired`, `RequiresEvidence`, `EvidenceTypes`).
+2. Negotiation semantics:
+   - Carrier can accept terms as-is, counter specific accessorial terms, or reject.
+   - Counter path uses deterministic reason codes (for example `AccessorialResponsibilityDispute`, `AccessorialPricingDispute`).
+3. Post-booking state contract (booking-plane scope only):
+   - Allowed state progression for accessorial claims: `Proposed -> Approved | Rejected`.
+   - `ExecutionReport` captures agreed framework and any claim references known at booking close.
+4. Evidence model:
+   - FAXP carries evidence references/metadata only (hash, external reference ID, URI).
+   - FAXP does not standardize file transfer, document custody, or proof adjudication workflows.
+5. Settlement boundary:
+   - Payment/invoice/remittance remains external to FAXP and must not be modeled as core protocol state.
+
+## Security Considerations
+1. Canonical accessorial typing and reason codes reduce semantic spoofing or ambiguity.
+2. Signed envelopes with replay/TTL protections continue to protect claim-state messages.
+3. Evidence references should be redacted/hashed where needed to avoid leaking sensitive document contents.
+
+## Compliance and Governance Considerations
+1. Canonical accessorial type registry remains governance-controlled and vendor-neutral.
+2. Profiles must define which accessorial types/terms are certifiable for a given environment.
+3. Governance docs must explicitly preserve settlement and document-custody out-of-scope boundaries.
+
+## Backward Compatibility
+1. Existing accessorial behavior remains valid; new fields are additive and optional.
+2. Agents not supporting extended lifecycle fields must fail closed with explicit validation reasons where required.
+3. Existing `PerMile`, `Flat`, `PerPallet`, and `CWT` behavior is unaffected.
+
+## Test Plan
+1. Schema validation tests for required/optional accessorial term fields.
+2. Negotiation tests for accept/counter/reject paths with deterministic reason codes.
+3. Execution-report snapshot tests to ensure agreed accessorial framework is auditable.
+4. Failure-mode tests for invalid type values, missing payer/payee responsibility, and invalid state transitions.
+5. Conformance profile checks and governance readiness checks updated.
+
+## Rollout Plan
+1. Approve RFC.
+2. Land conformance profile artifact/tests first.
+3. Land runtime/schema updates behind strict validation.
+4. Update Streamlit examples to reflect booking-plane lifecycle semantics.
+5. Include in next RC and run soak checks.
+
+## Alternatives Considered
+1. Keep free-form notes only: rejected due to high ambiguity and interoperability risk.
+2. Model full settlement lifecycle in FAXP: rejected as out of scope.
+3. Defer all accessorial lifecycle standardization to external systems: rejected due to persistent booking-plane negotiation friction.
+
+## Open Questions
+1. Final canonical claim-state names (`Proposed/Approved/Rejected` vs expanded state vocabulary).
+2. Whether any accessorial types require mandatory external verifier evidence references.
+3. Whether profile-level policy should permit auto-approval thresholds by accessorial type.
+
+## Approval
+- Maintainer Approval:
+- Governance Approval (if required):
+- Date:

--- a/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md
+++ b/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md
@@ -112,10 +112,12 @@ Purpose: Central place to capture commercial model requirements before implement
   - Added only via RFC with compatibility plan.
 
 2. Advanced accessorial lifecycle scenarios
-- Target: `deferred`
-- RFC: `TBD`
+- Target: `v0.3.x`
+- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md`
 - Acceptance:
-  - Clear pre-booking vs post-booking state boundaries.
+  - Clear pre-booking vs post-booking claim-state boundaries.
+  - Explicit booking-time payer/payee responsibility semantics.
+  - Evidence handled as references/metadata only; settlement remains out of scope.
 
 ### E) Scope-Lock Baseline (Commercial Terms)
 

--- a/docs/roadmap/V0_3_0_RFC_BACKLOG.md
+++ b/docs/roadmap/V0_3_0_RFC_BACKLOG.md
@@ -82,6 +82,14 @@ Scope policy: Booking-plane and certification governance only.
 - Notes: Keep implementation strictly booking-plane and fail closed for unsupported model fields.
 - Draft file: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md`
 
+9. `RFC-v0.3-accessorial-lifecycle-booking-plane`
+- Goal: Standardize accessorial booking-time terms, payer/payee responsibility, and post-booking claim states without entering settlement workflows.
+- Scope class: `In-Scope`
+- Status: `Draft` (Deferred to v0.3.x)
+- Target: `v0.3.x`
+- Notes: Evidence modeled as external references only; no document custody or payment rails in core protocol.
+- Draft file: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md`
+
 ## Deferred / Explicitly Out-of-Scope for v0.3.0 RFC Batch
 
 1. Dispatch operations model.

--- a/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md
+++ b/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md
@@ -152,6 +152,26 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
   - Final agreed-rate normalization remains auditable and deterministic in `ExecutionReport`.
   - Backward compatibility is preserved for existing rate models and profiles.
 
+### S16: Detention Terms Agreed at Booking
+
+- Description: Broker and carrier agree detention commercial terms at booking time, including rate basis and responsibility.
+- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md`
+- Target: `v0.3.x`
+- Expected outcome:
+  - Accessorial terms are explicit (type, pricing mode, payer/payee, pre-approval/evidence requirements).
+  - Bid accept/counter paths preserve deterministic reason codes for accessorial disputes.
+  - `ExecutionReport` snapshots agreed booking-plane accessorial framework.
+
+### S17: Post-Booking Accessorial Claim with External Evidence Reference
+
+- Description: Carrier proposes a post-booking accessorial claim and references external proof metadata (not raw documents) for review.
+- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md`
+- Target: `v0.3.x`
+- Expected outcome:
+  - Claim state follows booking-plane contract (`Proposed -> Approved|Rejected`).
+  - Evidence is represented as references/metadata only (ID/hash/URI), not custody workflow.
+  - Settlement/payment execution remains outside FAXP scope.
+
 ## Scenario Expansion Policy
 
 1. New scenario proposals must be added here first.


### PR DESCRIPTION
## Summary
- Adds new draft RFC:
  - `docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md`
- Wires commercial backlog item "Advanced accessorial lifecycle scenarios" to this RFC.
- Adds RFC backlog entry:
  - `RFC-v0.3-accessorial-lifecycle-booking-plane`
- Adds scenario mappings:
  - `S16` Detention terms agreed at booking
  - `S17` Post-booking accessorial claim with external evidence reference

## Scope
- Docs/governance planning only.
- Booking-plane only.
- Settlement/payment/document custody remain out of scope.

## Notes
- Evidence is modeled as references/metadata only (ID/hash/URI), not raw document workflows.
- No runtime/schema implementation in this PR.
