### PR TITLE
Activate PerHour and LaneMinimum rate models end-to-end

### DIFF
--- a/conformance/rate_model_profile.v1.json
+++ b/conformance/rate_model_profile.v1.json
@@ -5,11 +5,12 @@
     "PerMile",
     "Flat",
     "PerPallet",
-    "CWT"
+    "CWT",
+    "PerHour",
+    "LaneMinimum"
   ],
   "plannedRateModels": [
-    "Hourly",
-    "LaneMinimum"
+    "Tiered"
   ],
   "rateModelCatalog": {
     "PerMile": {
@@ -28,11 +29,15 @@
       "status": "active",
       "unitBasis": "cwt"
     },
-    "Hourly": {
-      "status": "planned",
+    "PerHour": {
+      "status": "active",
       "unitBasis": "hour"
     },
     "LaneMinimum": {
+      "status": "active",
+      "unitBasis": "lane"
+    },
+    "Tiered": {
       "status": "planned",
       "unitBasis": "lane"
     }
@@ -78,7 +83,7 @@
       ],
       "status": "active"
     },
-    "Hourly": {
+    "PerHour": {
       "requiredFields": [
         "UnitBasis",
         "Quantity"
@@ -86,9 +91,18 @@
       "allowedUnitBasis": [
         "hour"
       ],
-      "status": "planned"
+      "status": "active"
     },
     "LaneMinimum": {
+      "requiredFields": [
+        "UnitBasis"
+      ],
+      "allowedUnitBasis": [
+        "lane"
+      ],
+      "status": "active"
+    },
+    "Tiered": {
       "requiredFields": [
         "UnitBasis"
       ],
@@ -109,8 +123,8 @@
   "profileSignature": {
     "alg": "HMAC_SHA256",
     "kid": "faxp-governance-rate-profile-2026q1",
-    "payloadDigestSha256": "sha256:3f01a40fd40c233f5bea2d0cf6f79cb0128cec87f5b4dd8fca209f2ddf153326",
-    "sig": "722013907f10464e0c7b2d48625100ca7a86317d5df7fedd749771bd52382d25",
-    "signedAt": "2026-02-25T22:40:14Z"
+    "payloadDigestSha256": "sha256:6b305731b5811a45479aa01d55d8156b5d305f91f5ad2d6678498d9c1e882570",
+    "sig": "ab208ad80773f304db60135b9b39a7b85d01afa58612ab2d4d61622a8518dd60",
+    "signedAt": "2026-02-27T11:47:33Z"
   }
 }

--- a/faxp.schema.json
+++ b/faxp.schema.json
@@ -47,7 +47,7 @@
       "properties": {
         "RateModel": {
           "type": "string",
-          "enum": ["PerMile", "Flat", "PerPallet", "CWT"],
+          "enum": ["PerMile", "Flat", "PerPallet", "CWT", "PerHour", "LaneMinimum"],
           "description": "Executable models in v0.3 booking plane. Deferred models are tracked in conformance artifacts."
         },
         "Amount": { "type": "number", "minimum": 0 },
@@ -116,7 +116,7 @@
         "DestinationState": { "type": "string" },
         "EquipmentType": { "type": "string" },
         "PickupDate": { "type": "string" },
-        "RateModel": { "type": "string", "enum": ["PerMile", "Flat", "PerPallet", "CWT"] },
+        "RateModel": { "type": "string", "enum": ["PerMile", "Flat", "PerPallet", "CWT", "PerHour", "LaneMinimum"] },
         "UnitBasis": { "type": "string" },
         "MaxRate": { "type": "number", "minimum": 0 }
       },
@@ -164,7 +164,7 @@
         "EquipmentType": { "type": "string" },
         "AvailableFrom": { "type": "string" },
         "AvailableTo": { "type": "string" },
-        "RateModel": { "type": "string", "enum": ["PerMile", "Flat", "PerPallet", "CWT"] },
+        "RateModel": { "type": "string", "enum": ["PerMile", "Flat", "PerPallet", "CWT", "PerHour", "LaneMinimum"] },
         "UnitBasis": { "type": "string" },
         "MinRate": { "type": "number", "minimum": 0 },
         "MaxRate": { "type": "number", "minimum": 0 }

--- a/faxp.v0.2.schema.json
+++ b/faxp.v0.2.schema.json
@@ -47,7 +47,7 @@
       "properties": {
         "RateModel": {
           "type": "string",
-          "enum": ["PerMile", "Flat", "PerPallet", "CWT"],
+          "enum": ["PerMile", "Flat", "PerPallet", "CWT", "PerHour", "LaneMinimum"],
           "description": "Executable models in v0.3 booking plane. Deferred models are tracked in conformance artifacts."
         },
         "Amount": { "type": "number", "minimum": 0 },
@@ -116,7 +116,7 @@
         "DestinationState": { "type": "string" },
         "EquipmentType": { "type": "string" },
         "PickupDate": { "type": "string" },
-        "RateModel": { "type": "string", "enum": ["PerMile", "Flat", "PerPallet", "CWT"] },
+        "RateModel": { "type": "string", "enum": ["PerMile", "Flat", "PerPallet", "CWT", "PerHour", "LaneMinimum"] },
         "UnitBasis": { "type": "string" },
         "MaxRate": { "type": "number", "minimum": 0 }
       },
@@ -164,7 +164,7 @@
         "EquipmentType": { "type": "string" },
         "AvailableFrom": { "type": "string" },
         "AvailableTo": { "type": "string" },
-        "RateModel": { "type": "string", "enum": ["PerMile", "Flat", "PerPallet", "CWT"] },
+        "RateModel": { "type": "string", "enum": ["PerMile", "Flat", "PerPallet", "CWT", "PerHour", "LaneMinimum"] },
         "UnitBasis": { "type": "string" },
         "MinRate": { "type": "number", "minimum": 0 },
         "MaxRate": { "type": "number", "minimum": 0 }

--- a/faxp_mvp_simulation.py
+++ b/faxp_mvp_simulation.py
@@ -2247,7 +2247,7 @@ def parse_args():
     )
     parser.add_argument(
         "--rate-model",
-        choices=["PerMile", "Flat", "PerPallet", "CWT"],
+        choices=["PerMile", "Flat", "PerPallet", "CWT", "PerHour", "LaneMinimum"],
         default="PerMile",
         help="Base pricing method for this simulation run.",
     )
@@ -2478,6 +2478,10 @@ def now_utc():
 def default_floor_amount(rate_model):
     if rate_model == "Flat":
         return 1850.0
+    if rate_model == "LaneMinimum":
+        return 1850.0
+    if rate_model == "PerHour":
+        return 95.0
     if rate_model == "PerPallet":
         return 74.0
     if rate_model == "CWT":
@@ -2488,6 +2492,10 @@ def default_floor_amount(rate_model):
 def default_bid_amount(rate_model):
     if rate_model == "Flat":
         return 1950.0
+    if rate_model == "LaneMinimum":
+        return 1950.0
+    if rate_model == "PerHour":
+        return 110.0
     if rate_model == "PerPallet":
         return 79.0
     if rate_model == "CWT":
@@ -2498,6 +2506,10 @@ def default_bid_amount(rate_model):
 def default_search_max(rate_model):
     if rate_model == "Flat":
         return 2200.0
+    if rate_model == "LaneMinimum":
+        return 2200.0
+    if rate_model == "PerHour":
+        return 140.0
     if rate_model == "PerPallet":
         return 90.0
     if rate_model == "CWT":
@@ -2508,6 +2520,10 @@ def default_search_max(rate_model):
 def counter_amount(rate_model, floor_amount):
     if rate_model == "Flat":
         return round(floor_amount + 150.0, 2)
+    if rate_model == "LaneMinimum":
+        return round(floor_amount + 150.0, 2)
+    if rate_model == "PerHour":
+        return round(floor_amount + 8.0, 2)
     if rate_model == "PerPallet":
         return round(floor_amount + 4.0, 2)
     if rate_model == "CWT":
@@ -2520,6 +2536,8 @@ def default_rate_quantity(rate_model):
         return 26
     if rate_model == "CWT":
         return 420
+    if rate_model == "PerHour":
+        return 6
     return 1
 
 
@@ -2562,7 +2580,7 @@ def build_rate(rate_model, amount, **metadata):
             rate["AgreedMiles"] = default_agreed_miles()
         if "MilesSource" not in metadata:
             rate["MilesSource"] = "BrokerRouteGuide"
-    if rate_model in {"PerPallet", "CWT"} and "Quantity" not in metadata:
+    if rate_model in {"PerPallet", "CWT", "PerHour"} and "Quantity" not in metadata:
         rate["Quantity"] = default_rate_quantity(rate_model)
     for key, value in metadata.items():
         if value is not None:
@@ -2574,6 +2592,10 @@ def build_rate(rate_model, amount, **metadata):
 def format_rate(rate):
     if rate["RateModel"] == "Flat":
         return f"${rate['Amount']:.2f} flat"
+    if rate["RateModel"] == "LaneMinimum":
+        return f"${rate['Amount']:.2f} lane minimum"
+    if rate["RateModel"] == "PerHour":
+        return f"${rate['Amount']:.2f}/hour"
     if rate["RateModel"] == "PerPallet":
         return f"${rate['Amount']:.2f}/pallet"
     if rate["RateModel"] == "CWT":
@@ -2601,9 +2623,10 @@ RATE_MODEL_CATALOG = {
     "Flat": {"status": "active", "unitBasis": "load"},
     "PerPallet": {"status": "active", "unitBasis": "pallet"},
     "CWT": {"status": "active", "unitBasis": "cwt"},
+    "PerHour": {"status": "active", "unitBasis": "hour"},
+    "LaneMinimum": {"status": "active", "unitBasis": "lane"},
     # Planned models for post-v0.3 profile expansion.
-    "Hourly": {"status": "planned", "unitBasis": "hour"},
-    "LaneMinimum": {"status": "planned", "unitBasis": "lane"},
+    "Tiered": {"status": "planned", "unitBasis": "lane"},
 }
 VALID_RATE_MODELS = {
     name for name, details in RATE_MODEL_CATALOG.items() if details.get("status") == "active"
@@ -2623,7 +2646,6 @@ RATE_MODEL_REQUIREMENTS = {
         "allowedUnitBasis": ["load"],
         "status": "active",
     },
-    # Planned models are declared for roadmap visibility, not executable yet.
     "PerPallet": {
         "requiredFields": ["UnitBasis", "Quantity"],
         "allowedUnitBasis": ["pallet"],
@@ -2634,12 +2656,17 @@ RATE_MODEL_REQUIREMENTS = {
         "allowedUnitBasis": ["cwt"],
         "status": "active",
     },
-    "Hourly": {
+    "PerHour": {
         "requiredFields": ["UnitBasis", "Quantity"],
         "allowedUnitBasis": ["hour"],
-        "status": "planned",
+        "status": "active",
     },
     "LaneMinimum": {
+        "requiredFields": ["UnitBasis"],
+        "allowedUnitBasis": ["lane"],
+        "status": "active",
+    },
+    "Tiered": {
         "requiredFields": ["UnitBasis"],
         "allowedUnitBasis": ["lane"],
         "status": "planned",
@@ -3058,7 +3085,7 @@ def _validate_rate_model_requirements(rate, context):
             distance = float(rate["DistanceMiles"])
             if abs(distance - float(agreed_miles)) > 0.01:
                 raise ValueError(f"{context}.DistanceMiles must equal AgreedMiles for RateModel '{model}'.")
-    elif model in {"PerPallet", "CWT"}:
+    elif model in {"PerPallet", "CWT", "PerHour"}:
         quantity = rate.get("Quantity")
         if not isinstance(quantity, (int, float)) or quantity <= 0:
             raise ValueError(f"{context}.Quantity must be a positive number for RateModel '{model}'.")
@@ -3073,7 +3100,7 @@ def _validate_rate_search_requirements(search_body, context):
     if model == "PerMile":
         rate_stub.setdefault("AgreedMiles", default_agreed_miles())
         rate_stub.setdefault("MilesSource", "SearchRouteBasis")
-    if model in {"PerPallet", "CWT", "Hourly"}:
+    if model in {"PerPallet", "CWT", "PerHour"}:
         rate_stub.setdefault("Quantity", 1)
     _validate_rate_model_requirements(
         rate_stub,
@@ -5329,7 +5356,7 @@ class BrokerAgent:
             for field in ["AgreedMiles", "MilesSource", "MilesSourceVersion", "MilesCalculatedAt"]:
                 if field in truck["RateMin"]:
                     metadata[field] = truck["RateMin"][field]
-        if rate_model in {"PerPallet", "CWT"} and "Quantity" in truck["RateMin"]:
+        if rate_model in {"PerPallet", "CWT", "PerHour"} and "Quantity" in truck["RateMin"]:
             metadata["Quantity"] = truck["RateMin"]["Quantity"]
         truck_equipment_terms = _extract_equipment_terms(truck)
         return {
@@ -5446,7 +5473,7 @@ class CarrierAgent:
             for field in ["AgreedMiles", "MilesSource", "MilesSourceVersion", "MilesCalculatedAt"]:
                 if field in load["Rate"]:
                     metadata[field] = load["Rate"][field]
-        if rate_model in {"PerPallet", "CWT"} and "Quantity" in load["Rate"]:
+        if rate_model in {"PerPallet", "CWT", "PerHour"} and "Quantity" in load["Rate"]:
             metadata["Quantity"] = load["Rate"]["Quantity"]
         schedule_acceptance = {"Accepted": True, "Exceptions": []}
         for field in ["PickupTimeWindow", "DeliveryTimeWindow"]:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -548,7 +548,7 @@ with st.sidebar:
         st.text_input("Access Key", type="password", key="access_key_input")
     rate_model = st.selectbox(
         "Rate Model",
-        ["PerMile", "Flat", "PerPallet", "CWT"],
+        ["PerMile", "Flat", "PerPallet", "CWT", "PerHour", "LaneMinimum"],
         key="rate_model_select",
     )
     bid_amount = st.number_input(
@@ -556,7 +556,10 @@ with st.sidebar:
         min_value=0.0,
         step=0.01,
         format="%.2f",
-        help="PerMile uses $/mile. Flat uses total trip amount. PerPallet uses $/pallet. CWT uses $/cwt.",
+        help=(
+            "PerMile uses $/mile. Flat uses total trip amount. PerPallet uses $/pallet. "
+            "CWT uses $/cwt. PerHour uses $/hour. LaneMinimum uses a minimum total lane amount."
+        ),
         key="bid_amount_input",
     )
     response_type = st.selectbox(

--- a/tests/run_rate_model_extensibility.py
+++ b/tests/run_rate_model_extensibility.py
@@ -36,12 +36,12 @@ def _expect_validation_error(message_type: str, body: dict, text: str) -> None:
 
 def main() -> int:
     _assert(
-        VALID_RATE_MODELS == {"PerMile", "Flat", "PerPallet", "CWT"},
-        "active executable rate models must include PerMile, Flat, PerPallet, and CWT.",
+        VALID_RATE_MODELS == {"PerMile", "Flat", "PerPallet", "CWT", "PerHour", "LaneMinimum"},
+        "active executable rate models must include PerMile, Flat, PerPallet, CWT, PerHour, and LaneMinimum.",
     )
     _assert(
-        {"Hourly", "LaneMinimum"}.issubset(PLANNED_RATE_MODELS),
-        "planned future rate models should include Hourly and LaneMinimum.",
+        {"Tiered"}.issubset(PLANNED_RATE_MODELS),
+        "planned future rate models should include Tiered.",
     )
     _assert(
         RATE_MODEL_CATALOG.get("PerPallet", {}).get("status") == "active",
@@ -50,6 +50,14 @@ def main() -> int:
     _assert(
         RATE_MODEL_CATALOG.get("CWT", {}).get("status") == "active",
         "CWT should be marked as active.",
+    )
+    _assert(
+        RATE_MODEL_CATALOG.get("PerHour", {}).get("status") == "active",
+        "PerHour should be marked as active.",
+    )
+    _assert(
+        RATE_MODEL_CATALOG.get("LaneMinimum", {}).get("status") == "active",
+        "LaneMinimum should be marked as active.",
     )
 
     # Backward-compatible active model with optional extension fields.
@@ -95,6 +103,23 @@ def main() -> int:
     )
     validate_message_body("BidRequest", {"LoadID": "load-cwt-123", "Rate": cwt_rate})
 
+    per_hour_rate = build_rate(
+        "PerHour",
+        110.0,
+        UnitBasis="hour",
+        Quantity=6,
+        Notes="Local dwell-sensitive lane.",
+    )
+    validate_message_body("BidRequest", {"LoadID": "load-hour-123", "Rate": per_hour_rate})
+
+    lane_min_rate = build_rate(
+        "LaneMinimum",
+        1950.0,
+        UnitBasis="lane",
+        Notes="Lane floor contract.",
+    )
+    validate_message_body("BidRequest", {"LoadID": "load-lane-123", "Rate": lane_min_rate})
+
     invalid_distance = dict(per_mile_rate)
     invalid_distance["DistanceMiles"] = -1
     _expect_validation_error("BidRequest", {"LoadID": "load-123", "Rate": invalid_distance}, "DistanceMiles")
@@ -126,10 +151,9 @@ def main() -> int:
     )
 
     planned_model_rate = build_rate(
-        "Hourly",
+        "Tiered",
         180.0,
-        UnitBasis="hour",
-        Quantity=6,
+        UnitBasis="lane",
     )
     _expect_validation_error(
         "BidRequest",
@@ -143,7 +167,7 @@ def main() -> int:
             "DestinationState": "GA",
             "EquipmentType": "Reefer",
             "PickupDate": "2026-03-01",
-            "RateModel": "Hourly",
+            "RateModel": "Tiered",
             "MaxRate": 2500.0,
         },
         "RateModel",

--- a/tests/run_rate_model_requirements.py
+++ b/tests/run_rate_model_requirements.py
@@ -40,16 +40,21 @@ def main() -> int:
     flat_req = RATE_MODEL_REQUIREMENTS.get("Flat") or {}
     per_pallet_req = RATE_MODEL_REQUIREMENTS.get("PerPallet") or {}
     cwt_req = RATE_MODEL_REQUIREMENTS.get("CWT") or {}
+    per_hour_req = RATE_MODEL_REQUIREMENTS.get("PerHour") or {}
+    lane_min_req = RATE_MODEL_REQUIREMENTS.get("LaneMinimum") or {}
     _assert(per_mile_req.get("status") == "active", "PerMile requirements must be active.")
     _assert(flat_req.get("status") == "active", "Flat requirements must be active.")
     _assert(per_pallet_req.get("status") == "active", "PerPallet requirements must be active.")
     _assert(cwt_req.get("status") == "active", "CWT requirements must be active.")
+    _assert(per_hour_req.get("status") == "active", "PerHour requirements must be active.")
+    _assert(lane_min_req.get("status") == "active", "LaneMinimum requirements must be active.")
     _assert("UnitBasis" in (per_mile_req.get("requiredFields") or []), "PerMile must require UnitBasis.")
     _assert("AgreedMiles" in (per_mile_req.get("requiredFields") or []), "PerMile must require AgreedMiles.")
     _assert("MilesSource" in (per_mile_req.get("requiredFields") or []), "PerMile must require MilesSource.")
     _assert("UnitBasis" in (flat_req.get("requiredFields") or []), "Flat must require UnitBasis.")
     _assert("Quantity" in (per_pallet_req.get("requiredFields") or []), "PerPallet must require Quantity.")
     _assert("Quantity" in (cwt_req.get("requiredFields") or []), "CWT must require Quantity.")
+    _assert("Quantity" in (per_hour_req.get("requiredFields") or []), "PerHour must require Quantity.")
 
     valid_per_mile = build_rate("PerMile", 2.62)
     validate_message_body("BidRequest", {"LoadID": "load-permile-ok", "Rate": valid_per_mile})
@@ -62,6 +67,12 @@ def main() -> int:
 
     valid_cwt = build_rate("CWT", 5.1)
     validate_message_body("BidRequest", {"LoadID": "load-cwt-ok", "Rate": valid_cwt})
+
+    valid_per_hour = build_rate("PerHour", 110.0)
+    validate_message_body("BidRequest", {"LoadID": "load-perhour-ok", "Rate": valid_per_hour})
+
+    valid_lane_min = build_rate("LaneMinimum", 1950.0)
+    validate_message_body("BidRequest", {"LoadID": "load-lanemin-ok", "Rate": valid_lane_min})
 
     missing_unit_basis = {"RateModel": "PerMile", "Amount": 2.62, "Currency": "USD"}
     _expect_validation_error(
@@ -111,6 +122,27 @@ def main() -> int:
         "BidRequest",
         {"LoadID": "load-cwt-bad-basis", "Rate": invalid_cwt_basis},
         "UnitBasis must be one of ['cwt']",
+    )
+
+    invalid_per_hour_basis = build_rate("PerHour", 110.0, UnitBasis="mile")
+    _expect_validation_error(
+        "BidRequest",
+        {"LoadID": "load-perhour-bad-basis", "Rate": invalid_per_hour_basis},
+        "UnitBasis must be one of ['hour']",
+    )
+
+    invalid_per_hour_quantity = build_rate("PerHour", 110.0, Quantity=0)
+    _expect_validation_error(
+        "BidRequest",
+        {"LoadID": "load-perhour-bad-quantity", "Rate": invalid_per_hour_quantity},
+        "Quantity must be a positive number for RateModel 'PerHour'",
+    )
+
+    invalid_lane_min_basis = build_rate("LaneMinimum", 1950.0, UnitBasis="load")
+    _expect_validation_error(
+        "BidRequest",
+        {"LoadID": "load-lanemin-bad-basis", "Rate": invalid_lane_min_basis},
+        "UnitBasis must be one of ['lane']",
     )
 
     broker = BrokerAgent("Broker Agent")

--- a/tests/run_rate_search_requirements.py
+++ b/tests/run_rate_search_requirements.py
@@ -49,6 +49,12 @@ def main() -> int:
     valid_cwt_truck_search = broker.create_truck_search(rate_model="CWT")
     validate_message_body("TruckSearch", valid_cwt_truck_search)
 
+    valid_per_hour_search = carrier.create_load_search(force_no_match=False, rate_model="PerHour")
+    validate_message_body("LoadSearch", valid_per_hour_search)
+
+    valid_lane_min_truck_search = broker.create_truck_search(rate_model="LaneMinimum")
+    validate_message_body("TruckSearch", valid_lane_min_truck_search)
+
     missing_basis_load = {
         "OriginState": "TX",
         "DestinationState": "GA",
@@ -124,6 +130,38 @@ def main() -> int:
         "TruckSearch",
         invalid_basis_cwt_truck,
         "TruckSearch.UnitBasis must be one of ['cwt']",
+    )
+
+    invalid_basis_per_hour_load = {
+        "OriginState": "TX",
+        "DestinationState": "GA",
+        "EquipmentType": "Reefer",
+        "PickupDate": "2026-03-01",
+        "RateModel": "PerHour",
+        "UnitBasis": "mile",
+        "MaxRate": default_search_max("PerHour"),
+    }
+    _expect_validation_error(
+        "LoadSearch",
+        invalid_basis_per_hour_load,
+        "LoadSearch.UnitBasis must be one of ['hour']",
+    )
+
+    invalid_basis_lane_min_truck = {
+        "LocationRadiusMiles": 120,
+        "OriginState": "TX",
+        "EquipmentType": "Reefer",
+        "AvailableFrom": "2026-03-01",
+        "AvailableTo": "2026-03-02",
+        "RateModel": "LaneMinimum",
+        "UnitBasis": "load",
+        "MinRate": 1800.0,
+        "MaxRate": 2200.0,
+    }
+    _expect_validation_error(
+        "TruckSearch",
+        invalid_basis_lane_min_truck,
+        "TruckSearch.UnitBasis must be one of ['lane']",
     )
 
     print("Rate search requirement checks passed.")


### PR DESCRIPTION
## Summary
- activates `PerHour` and `LaneMinimum` as executable booking-plane rate models
- updates runtime defaults and validation paths
- updates Streamlit rate model selector/help
- updates `faxp.schema.json` and `faxp.v0.2.schema.json` enums
- updates rate-model conformance profile and signature
- updates regression tests for extensibility, requirements, and search requirements

## Scope
- booking-plane pricing model expansion only
- no dispatch/tracking/settlement scope expansion

## Verification
Passed:
- tests/run_rate_model_extensibility.py
- tests/run_rate_model_requirements.py
- tests/run_rate_search_requirements.py
- tests/run_rate_model_profile.py
- tests/run_rate_model_profile_signature.py
- tests/run_schema_compatibility.py
- tests/run_streamlit_state_logic.py
- tests/run_conformance_suite.py
- tests/run_release_readiness.py
