### PR TITLE
Add booking-plane accessorial claim lifecycle states and Streamlit claim resolution

### DIFF
--- a/conformance/accessorial_terms_profile.v1.json
+++ b/conformance/accessorial_terms_profile.v1.json
@@ -48,10 +48,9 @@
     "Other"
   ],
   "entryStatuses": [
-    "Pending",
+    "Proposed",
     "Approved",
-    "Rejected",
-    "TBD"
+    "Rejected"
   ],
   "normativeConstraints": {
     "nonUsdNotSupportedInV011": true,

--- a/faxp_mvp_simulation.py
+++ b/faxp_mvp_simulation.py
@@ -2702,7 +2702,7 @@ PLANNED_ACCESSORIAL_TYPES = tuple(
 )
 VALID_ACCESSORIAL_PARTIES = {"Broker", "Carrier", "Shipper", "Vendor", "Unknown"}
 VALID_ACCESSORIAL_EVIDENCE_TYPES = {"Receipt", "Permit", "EscortInvoice", "Other"}
-VALID_ACCESSORIAL_STATUSES = {"Pending", "Approved", "Rejected", "TBD"}
+VALID_ACCESSORIAL_STATUSES = {"Proposed", "Approved", "Rejected"}
 VALID_DETENTION_RATE_UNITS = {"Hour"}
 VALID_DETENTION_LOCATION_EVIDENCE_TYPES = {"GPS", "ELDPosition", "GeofenceCheckIn", "Other"}
 VALID_STOP_TYPES = {"Pickup", "Drop"}
@@ -3382,10 +3382,28 @@ def _validate_accessorial_entries(accessorials, context, allowed_types=None):
                 raise ValueError(
                     f"{item_context}.Status must be one of {sorted(VALID_ACCESSORIAL_STATUSES)}."
                 )
+        status = item.get("Status")
+        if status == "Proposed":
+            _require_fields(item, ["ClaimID"], item_context)
+            _bounded_string(item["ClaimID"], f"{item_context}.ClaimID")
+            if "ProposedAt" in item:
+                _validate_iso_datetime(item["ProposedAt"], f"{item_context}.ProposedAt")
+            if "ApprovedAt" in item:
+                raise ValueError(f"{item_context}.ApprovedAt is not allowed for Status 'Proposed'.")
+            if "RejectedAt" in item:
+                raise ValueError(f"{item_context}.RejectedAt is not allowed for Status 'Proposed'.")
+        elif status == "Approved":
+            _require_fields(item, ["ApprovedAt"], item_context)
+        elif status == "Rejected":
+            _require_fields(item, ["RejectedAt"], item_context)
         if "ApprovedAt" in item:
             _validate_iso_datetime(item["ApprovedAt"], f"{item_context}.ApprovedAt")
+        if "RejectedAt" in item:
+            _validate_iso_datetime(item["RejectedAt"], f"{item_context}.RejectedAt")
         if "EvidenceRef" in item:
             _bounded_string(item["EvidenceRef"], f"{item_context}.EvidenceRef")
+        if "EvidenceRefs" in item:
+            _validate_string_array(item["EvidenceRefs"], f"{item_context}.EvidenceRefs")
         if "SettlementReference" in item:
             _bounded_string(item["SettlementReference"], f"{item_context}.SettlementReference")
         if "Note" in item:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -280,15 +280,21 @@ def update_summary_from_report():
         )
 
 
-def approve_accessorial(accessorial_type, amount, note):
+def _accessorial_term_metadata(policy, accessorial_type):
+    for term in policy.get("Terms", []):
+        if isinstance(term, dict) and term.get("Type") == accessorial_type:
+            return term
+    return {}
+
+
+def submit_accessorial_claim(accessorial_type, amount, note, evidence_ref):
     report = st.session_state.execution_report
     if report is None:
-        st.session_state.status_line = "No booked load available for accessorial approval."
+        st.session_state.status_line = "No booked load available for accessorial claim."
         return
 
     policy = report.get("AccessorialPolicy", {})
     allowed_types = policy.get("AllowedTypes", [])
-    max_total = float(policy.get("MaxTotal", 0.0))
 
     if accessorial_type not in allowed_types:
         st.session_state.status_line = f"Accessorial '{accessorial_type}' is not allowed by policy."
@@ -298,33 +304,81 @@ def approve_accessorial(accessorial_type, amount, note):
         st.session_state.status_line = "Accessorial amount must be greater than zero."
         return
 
-    new_total = accessorial_total(report) + float(amount)
-    if max_total > 0 and new_total > max_total:
-        st.session_state.status_line = f"Accessorial exceeds policy max (${max_total:.2f})."
-        return
-
-    term_metadata = {}
-    for term in policy.get("Terms", []):
-        if isinstance(term, dict) and term.get("Type") == accessorial_type:
-            term_metadata = term
-            break
+    term_metadata = _accessorial_term_metadata(policy, accessorial_type)
+    claim_id = f"CLM-{int(time.time() * 1000)}"
+    entry = {
+        "Type": accessorial_type,
+        "ClaimID": claim_id,
+        "Amount": round(float(amount), 2),
+        "Currency": policy.get("Currency", "USD"),
+        "Status": "Proposed",
+        "ProposedAt": now_utc(),
+        "PricingMode": term_metadata.get("PricingMode", "Reimbursable"),
+        "PayerParty": term_metadata.get("PayerParty", "Broker"),
+        "PayeeParty": term_metadata.get("PayeeParty", "Carrier"),
+        "EvidenceRequired": bool(term_metadata.get("EvidenceRequired", False)),
+        "EvidenceType": term_metadata.get("EvidenceType", "Other"),
+        "Note": note.strip(),
+    }
+    evidence_ref_value = str(evidence_ref or "").strip()
+    if evidence_ref_value:
+        entry["EvidenceRefs"] = [evidence_ref_value]
+        entry["EvidenceRef"] = evidence_ref_value
 
     report["Accessorials"].append(
-        {
-            "Type": accessorial_type,
-            "Amount": round(float(amount), 2),
-            "Currency": policy.get("Currency", "USD"),
-            "Status": "Approved",
-            "ApprovedAt": now_utc(),
-            "PricingMode": term_metadata.get("PricingMode", "Reimbursable"),
-            "PayerParty": term_metadata.get("PayerParty", "Broker"),
-            "PayeeParty": term_metadata.get("PayeeParty", "Carrier"),
-            "EvidenceRequired": bool(term_metadata.get("EvidenceRequired", False)),
-            "EvidenceType": term_metadata.get("EvidenceType", "Other"),
-            "Note": note.strip(),
-        }
+        entry
     )
-    st.session_state.status_line = f"Accessorial approved: {accessorial_type} ${float(amount):.2f}"
+    st.session_state.status_line = f"Accessorial claim proposed: {accessorial_type} ${float(amount):.2f}"
+    update_summary_from_report()
+
+
+def resolve_accessorial_claim(claim_id, decision, resolution_note):
+    report = st.session_state.execution_report
+    if report is None:
+        st.session_state.status_line = "No booked load available for accessorial claim resolution."
+        return
+    if decision not in {"Approved", "Rejected"}:
+        st.session_state.status_line = "Resolution decision must be Approved or Rejected."
+        return
+    claim_id_value = str(claim_id or "").strip()
+    if not claim_id_value:
+        st.session_state.status_line = "Select a claim to resolve."
+        return
+
+    target_entry = None
+    for entry in report.get("Accessorials", []):
+        if entry.get("ClaimID") == claim_id_value:
+            target_entry = entry
+            break
+
+    if target_entry is None:
+        st.session_state.status_line = f"Claim not found: {claim_id_value}"
+        return
+
+    if target_entry.get("Status") != "Proposed":
+        st.session_state.status_line = f"Claim {claim_id_value} is already resolved."
+        return
+
+    policy = report.get("AccessorialPolicy", {})
+    max_total = float(policy.get("MaxTotal", 0.0))
+    if decision == "Approved":
+        proposed_amount = float(target_entry.get("Amount", 0.0))
+        new_total = accessorial_total(report) + proposed_amount
+        if max_total > 0 and new_total > max_total:
+            st.session_state.status_line = f"Accessorial exceeds policy max (${max_total:.2f})."
+            return
+        target_entry["Status"] = "Approved"
+        target_entry["ApprovedAt"] = now_utc()
+        target_entry.pop("RejectedAt", None)
+    else:
+        target_entry["Status"] = "Rejected"
+        target_entry["RejectedAt"] = now_utc()
+        target_entry.pop("ApprovedAt", None)
+
+    note_value = str(resolution_note or "").strip()
+    if note_value:
+        target_entry["ResolutionNote"] = note_value
+    st.session_state.status_line = f"Accessorial claim {decision.lower()}: {claim_id_value}"
     update_summary_from_report()
 
 
@@ -991,9 +1045,50 @@ if st.session_state.execution_report is not None:
         key="accessorial_note",
         placeholder="Example: Receiver required hand-unload",
     )
-    approve_clicked = st.button("Approve Accessorial", use_container_width=False)
-    if approve_clicked:
-        approve_accessorial(accessorial_type, accessorial_amount, accessorial_note)
+    accessorial_evidence_ref = st.text_input(
+        "Evidence Ref (optional)",
+        key="accessorial_evidence_ref",
+        placeholder="Example: receipt-2026-0001",
+    )
+    submit_claim_clicked = st.button("Submit Accessorial Claim (Proposed)", use_container_width=False)
+    if submit_claim_clicked:
+        submit_accessorial_claim(
+            accessorial_type,
+            accessorial_amount,
+            accessorial_note,
+            accessorial_evidence_ref,
+        )
+
+    proposed_claims = [
+        item
+        for item in st.session_state.execution_report.get("Accessorials", [])
+        if item.get("Status") == "Proposed" and item.get("ClaimID")
+    ]
+    if proposed_claims:
+        selected_claim_id = st.selectbox(
+            "Proposed Claim",
+            options=[item["ClaimID"] for item in proposed_claims],
+            key="accessorial_claim_id",
+            format_func=lambda cid: (
+                f"{cid} | "
+                f"{next((entry.get('Type') for entry in proposed_claims if entry.get('ClaimID') == cid), 'Unknown')} | "
+                f"${float(next((entry.get('Amount') for entry in proposed_claims if entry.get('ClaimID') == cid), 0.0)):.2f}"
+            ),
+        )
+        resolution_note = st.text_input(
+            "Resolution Note (optional)",
+            key="accessorial_resolution_note",
+            placeholder="Example: Approved with receiver delay proof",
+        )
+        col_approve, col_reject = st.columns(2)
+        with col_approve:
+            approve_claim_clicked = st.button("Approve Selected Claim", use_container_width=True)
+        with col_reject:
+            reject_claim_clicked = st.button("Reject Selected Claim", use_container_width=True)
+        if approve_claim_clicked:
+            resolve_accessorial_claim(selected_claim_id, "Approved", resolution_note)
+        if reject_claim_clicked:
+            resolve_accessorial_claim(selected_claim_id, "Rejected", resolution_note)
 
     st.subheader("Execution Report")
     st.json(redact_sensitive(st.session_state.execution_report))

--- a/tests/run_accessorial_terms.py
+++ b/tests/run_accessorial_terms.py
@@ -228,6 +228,65 @@ def main() -> int:
         }
         validate_message_body("ExecutionReport", execution_report)
 
+        proposed_claim_report = {
+            **execution_report,
+            "Accessorials": [
+                {
+                    "Type": "UnloadingFee",
+                    "ClaimID": "CLM-2026-0001",
+                    "Amount": 85.0,
+                    "Currency": "USD",
+                    "Status": "Proposed",
+                    "ProposedAt": now_utc(),
+                    "PricingMode": "Reimbursable",
+                    "PayerParty": "Broker",
+                    "PayeeParty": "Carrier",
+                    "EvidenceRequired": True,
+                    "EvidenceType": "Receipt",
+                    "EvidenceRefs": ["receipt-2026-0001"],
+                }
+            ],
+        }
+        validate_message_body("ExecutionReport", proposed_claim_report)
+
+        missing_claim_id_report = {
+            **proposed_claim_report,
+            "Accessorials": [
+                {
+                    "Type": "UnloadingFee",
+                    "Amount": 85.0,
+                    "Currency": "USD",
+                    "Status": "Proposed",
+                    "ProposedAt": now_utc(),
+                }
+            ],
+        }
+        _expect_validation_error(
+            "ExecutionReport",
+            missing_claim_id_report,
+            "missing required fields",
+        )
+
+        rejected_claim_report = {
+            **execution_report,
+            "Accessorials": [
+                {
+                    "Type": "EscortVehicle",
+                    "ClaimID": "CLM-2026-0002",
+                    "Amount": 250.0,
+                    "Currency": "USD",
+                    "Status": "Rejected",
+                    "RejectedAt": now_utc(),
+                    "PricingMode": "TBD",
+                    "PayerParty": "Broker",
+                    "PayeeParty": "Vendor",
+                    "EvidenceRequired": True,
+                    "EvidenceType": "EscortInvoice",
+                }
+            ],
+        }
+        validate_message_body("ExecutionReport", rejected_claim_report)
+
         bad_execution = {
             **execution_report,
             "Accessorials": [


### PR DESCRIPTION
## Summary
- standardizes accessorial claim states to:
  - Proposed
  - Approved
  - Rejected
- enforces state-specific validation in protocol runtime:
  - Proposed requires ClaimID
  - Approved requires ApprovedAt
  - Rejected requires RejectedAt
- adds support for EvidenceRefs on accessorial claim entries
- updates accessorial terms profile status contract
- updates Streamlit post-booking flow:
  - submit claim as Proposed
  - approve/reject selected Proposed claim

## Scope
- booking-plane commercial claim lifecycle only
- no settlement/payment rail implementation
- no dispatch/tracking scope expansion

## Validation
Passed:
- tests/run_accessorial_terms.py
- tests/run_accessorial_terms_profile.py
- tests/run_streamlit_state_logic.py
- tests/run_conformance_suite.py
- tests/run_release_readiness.py
- conformance/run_all_checks.py
