### PR TITLE
Add public release documentation and contributor/security templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @truckingadvantage

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report a protocol, conformance, or documentation defect
+title: "[BUG] "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+What is wrong?
+
+## Reproduction
+
+Steps to reproduce:
+1.
+2.
+3.
+
+## Expected behavior
+
+What should happen?
+
+## Actual behavior
+
+What happened instead?
+
+## Environment
+
+- Branch/tag:
+- Local OS:
+- Python version:
+
+## Logs or output
+
+Paste relevant output or attach screenshots.
+
+## Scope relevance
+
+Does this involve booking-plane scope, conformance tooling, or governance artifacts?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,36 @@
+---
+name: Feature request
+about: Propose a protocol, conformance, or governance enhancement
+title: "[FEATURE] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem statement
+
+What problem are you solving?
+
+## Proposed change
+
+Describe the proposed behavior.
+
+## Scope classification
+
+- [ ] Booking-plane in-scope
+- [ ] Scope-adjacent (needs RFC)
+- [ ] Out-of-scope for protocol core
+
+## Alternatives considered
+
+What alternatives did you evaluate?
+
+## Impact
+
+Expected impact on:
+- protocol contracts
+- conformance profiles/tests
+- governance artifacts
+
+## References
+
+Link RFCs/issues/docs.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Summary
+
+Describe what changed and why.
+
+## Scope Check
+
+- [ ] I reviewed `docs/governance/SCOPE_GUARDRAILS.md`.
+- [ ] This change stays within booking-plane scope.
+- [ ] If this is scope-adjacent, I linked an RFC.
+
+## Validation
+
+List commands run and outcomes.
+
+```bash
+# paste commands here
+```
+
+## Governance/Conformance Impact
+
+- [ ] No governance artifacts changed.
+- [ ] Governance artifacts changed and I updated:
+  - [ ] `docs/governance/GOVERNANCE_INDEX.json`
+  - [ ] `docs/governance/RELEASE_READINESS_CHECKLIST.md`
+  - [ ] related conformance profile/tests
+
+## Security and Secrets
+
+- [ ] No secrets or key material were added.
+- [ ] Security-sensitive behavior was reviewed.
+
+## Related
+
+- RFC:
+- Issue:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to FAXP
+
+## Contribution Types
+
+- Protocol and schema improvements
+- Conformance profile and test additions
+- Governance and release-gate documentation improvements
+- Bug fixes aligned to current scope guardrails
+
+## Scope Guardrails
+
+Before opening a PR, read:
+- `docs/governance/SCOPE_GUARDRAILS.md`
+- `docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
+
+Changes that expand into dispatch/tracking/settlement domains require an RFC and explicit approval.
+
+## Development Workflow
+
+1. Create a branch from `main`.
+2. Keep PRs focused and small.
+3. Add or update tests for any behavior change.
+4. Run relevant checks locally before pushing.
+
+Recommended local checks:
+
+```bash
+./scripts/run_a2a_conformance.sh
+./scripts/run_mcp_conformance.sh
+python3 conformance/run_all_checks.py --output /tmp/faxp_conformance_suite_report.local.json
+python3 tests/run_release_readiness.py
+```
+
+## RFC Requirement
+
+Use RFC flow for:
+- new message contracts
+- schema compatibility changes
+- new governance profiles
+- scope-adjacent policy shifts
+
+Template:
+- `docs/rfc/RFC_TEMPLATE.md`
+
+## Commit and PR Expectations
+
+- Use clear, action-oriented commit messages.
+- Link related RFCs/issues in PR description.
+- Include validation commands and results.
+- Keep sensitive material out of commits.
+
+## Security and Secrets
+
+- Never commit private keys, tokens, or local secret bundles.
+- Follow `SECURITY.md` for vulnerability reporting.
+
+## Review and Merge
+
+- Required CI checks must pass.
+- Changes to governance artifacts must keep governance index and release-readiness checks green.

--- a/README.md
+++ b/README.md
@@ -1,263 +1,106 @@
-# FAXP (Freight Agent eXchange Protocol)
+# FAXP
 
-FAXP is a runnable protocol demo for autonomous freight booking.
+FAXP (Freight Agent eXchange Protocol) is an open, vendor-neutral booking-plane protocol for agent-to-agent freight matching and booking confirmation.
 
-This repository includes:
-- `faxp_mvp_simulation.py` for CLI simulation (load flow + truck flow).
-- `streamlit_app.py` for interactive demo UI.
-- `adapter/fmcsa_live.py` for FMCSA live-query parser/client code used by builder-hosted adapters.
-- `adapter/INTERFACE.md` for the stable adapter request/response and security contract.
-- `fmcsa_adapter_server.py` as the reference hosted FMCSA adapter implementation.
-- Security controls (message signing, verifier signing, replay/TTL, key rotation, incident drill).
-- CI checks for parser regressions, Streamlit state regressions, and schema compatibility.
+## Scope
 
-## One-Command Local Release Smoke
+In scope:
+- Agent message envelopes, signatures, replay/TTL checks, and validation.
+- Booking workflow message types:
+  - `NewLoad`, `LoadSearch`
+  - `NewTruck`, `TruckSearch`
+  - `BidRequest`, `BidResponse`
+  - `ExecutionReport`, `AmendRequest`
+- Optional verification evidence transport and policy decisions that affect booking outcome.
+- Conformance profiles, certification artifacts, and governance checks.
 
-Run the same local-mode gate path used for release validation:
+Out of scope:
+- Dispatch execution.
+- Telematics and tracking lifecycle.
+- POD/BOL custody lifecycle.
+- Invoicing, remittance, payment rails, and settlement operations.
+- FAXP-hosted verifier operations.
+
+Canonical boundary docs:
+- `docs/governance/SCOPE_GUARDRAILS.md`
+- `docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`
+
+## Repository Contents
+
+- `faxp_mvp_simulation.py`: CLI protocol simulation.
+- `streamlit_app.py`: interactive demo.
+- `conformance/`: profiles, artifacts, and full conformance harness.
+- `docs/`: governance, RFCs, roadmap, and release notes.
+- `adapter/`: adapter interface and reference implementation components.
+
+## Quick Start
 
 ```bash
 cd /Users/zglitch009/projects/logistics-ai/FIX-F
-./scripts/run_release_smoke_local.sh
-```
-
-Optional conformance report path:
-
-```bash
-./scripts/run_release_smoke_local.sh /tmp/faxp_conformance_suite_report.local_smoke.json
-```
-
-## Release Checkpoints
-
-- `v0.2.0-alpha.1`: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/releases/RELEASE_NOTES_v0.2.0-alpha.1.md`
-- `v0.2.0-rc.1`: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/releases/RELEASE_CANDIDATE_v0.2.0-rc.1.md`
-- `v0.2.0-rc.2`: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/releases/RELEASE_CANDIDATE_v0.2.0-rc.2.md`
-- `v0.2.0-rc.3`: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/releases/RELEASE_CANDIDATE_v0.2.0-rc.3.md`
-- `v0.2.0`: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/releases/RELEASE_NOTES_v0.2.0.md`
-
-## Post-v0.2 Planning Tracks
-
-- `v0.2.1` patch-only plan: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_2_1_PATCH_PLAN.md`
-- `v0.3.0` RFC backlog (planning-only): `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_RFC_BACKLOG.md`
-- `v0.3.0` governance checkpoint: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_GOVERNANCE_CHECKPOINT.md`
-- `v0.3.0` commercial model backlog: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md`
-- `v0.3.0` scenario catalog: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md`
-- Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
-- Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-shipper-orchestration-minimal.md`
-- Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-schema-version-negotiation.md`
-- Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-adapter-certification-profile-v2.md`
-- Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md`
-- Active RFC draft: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-a2a-mcp-interop-maturity.md`
-
-## v0.2 Planning Artifacts
-
-- Docs index: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/INDEX.md`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.2-verification-neutrality.md`
-- A2A compatibility profile: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/A2A_COMPATIBILITY_PROFILE.md`
-- A2A change management: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/A2A_CHANGE_MANAGEMENT.md`
-- A2A upstream tracking config: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/A2A_UPSTREAM_TRACKING.json`
-- MCP compatibility profile: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/MCP_COMPATIBILITY_PROFILE.md`
-- MCP change management: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/MCP_CHANGE_MANAGEMENT.md`
-- MCP upstream tracking config: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/MCP_UPSTREAM_TRACKING.json`
-- Implementation checklist: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V2_IMPLEMENTATION_CHECKLIST.md`
-- Test matrix: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/TEST_MATRIX_v0.2.md`
-- Policy profiles (normative): `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/POLICY_PROFILES.md`
-- Schema files:
-  - v0.1.1: `/Users/zglitch009/projects/logistics-ai/FAXP/faxp.schema.json`
-  - v0.2 compatibility track: `/Users/zglitch009/projects/logistics-ai/FAXP/faxp.v0.2.schema.json`
-- Governance model: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/FAXP_GOVERNANCE_MODEL.md`
-- Builder handoff checklist: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/adapters/ADAPTER_IMPLEMENTER_HANDOFF.md`
-- Certification playbook: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/CERTIFICATION_PLAYBOOK.md`
-- Decision records runbook: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/DECISION_RECORDS_RUNBOOK.md`
-- Registry operations runbook: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/REGISTRY_OPERATIONS_RUNBOOK.md`
-- Registry changelog policy: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/REGISTRY_CHANGELOG_POLICY.md`
-- Governance index: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/GOVERNANCE_INDEX.json`
-- Release readiness checklist: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/RELEASE_READINESS_CHECKLIST.md`
-- Verification profiles:
-  - schema: `/Users/zglitch009/projects/logistics-ai/FAXP/profiles/verification/profile.schema.json`
-  - strict: `/Users/zglitch009/projects/logistics-ai/FAXP/profiles/verification/US_FMCSA_STRICT_V1.json`
-  - soft-hold: `/Users/zglitch009/projects/logistics-ai/FAXP/profiles/verification/US_FMCSA_SOFTHOLD_V1.json`
-  - balanced: `/Users/zglitch009/projects/logistics-ai/FAXP/profiles/verification/US_FMCSA_BALANCED_V1.json`
-- Conformance and registry artifacts:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/README.md`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/certification_registry.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/certification_registry.sample.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/adapter_profile.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/adapter_profile.sample.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/adapter_test_profile.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/fmcsa_adapter_test_profile.v1.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/submission_manifest.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/submission_manifest.sample.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/submission_manifest_keys.sample.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/key_lifecycle_policy.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/key_lifecycle_policy.sample.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/sample_conformance_report.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/registry_update.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/registry_update.sample.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/registry_update.sample.audit.log`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/registry_changelog.sample.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_governance_index.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_release_readiness.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/registry_update_keys.sample.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/certification_registry.sample.after_update.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/attestation_keys.sample.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/generate_attestation.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/create_submission_manifest.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/create_registry_update.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/apply_registry_update.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/run_all_checks.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/submission_manifest_signing.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/registry_update_signing.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/conformance_bundle.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/verifier_translator.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/a2a_bridge_translator.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/a2a_translator_contract.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/a2a_roundtrip_fixtures.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/mcp_tooling_contract.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/quickstart/`
-
-## Protocol Neutrality Boundary
-
-- Core FAXP handles envelope format, validation, message signing, replay/TTL controls, and conformance checks.
-- Provider integrations (FMCSA, biometric vendors, future verifiers) are adapter concerns and should remain outside protocol-core contracts.
-- `VerificationResult.provider` remains an opaque string in v0.2 compatibility schema; no vendor enum is required.
-- Production adapters are expected to be implementer-hosted; FAXP provides reference implementation + certification contracts.
-- Responsibility split is defined in `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`.
-
-## Legacy Field Deprecation Timeline
-
-Legacy provider-shaped fields remain supported for compatibility in v0.2:
-- `providerAlias`
-- `source`
-- `sourceAuthority`
-- `mcNumber`
-- `carrier`
-- `error`
-
-Planned lifecycle:
-1. v0.2.x: Supported and validated.
-2. v0.3.x: Still accepted, marked deprecated in docs and conformance notes.
-3. v0.4.0 target: move legacy fields to optional adapter-profile extensions; core conformance will only require neutral fields.
-
-Operational rule:
-- New integrations should write neutral fields first (`category`, `method`, `provider`, `assuranceLevel`, `evidenceRef`, `attestation`) and treat legacy fields as optional metadata.
-
-A2A bridge quick check:
-```bash
-./scripts/run_a2a_conformance.sh
-```
-
-MCP interop quick check:
-```bash
-./scripts/run_mcp_conformance.sh
-```
-
-MCP upstream watch check:
-```bash
-python3 scripts/check_mcp_upstream.py \
-  --tracking docs/interop/MCP_UPSTREAM_TRACKING.json \
-  --output /tmp/mcp_watch_report.json \
-  --issue-body /tmp/mcp_watch_issue.md
-```
-
-## Runbook
-
-### 1) Local Setup (Recommended)
-
-```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
 python3 -m venv .venv
 source .venv/bin/activate
 python3 -m pip install -U pip
 python3 -m pip install -r requirements.txt
 ```
 
-Generate local keys and env bundle:
+Generate local security material:
 
 ```bash
 ./scripts/generate_faxp_keys.sh /Users/zglitch009/.faxp-secrets
-```
-
-Load secrets:
-
-```bash
 set -a
 source /Users/zglitch009/.faxp-secrets/security.env.local
 set +a
 ```
 
-### 2) Run the Simulation (CLI)
-
-Default secure simulation:
+Run release smoke locally:
 
 ```bash
-./scripts/run_secure_demo.sh sim
+./scripts/run_release_smoke_local.sh
 ```
 
-Hosted FMCSA adapter simulation path:
-
-```bash
-python3 faxp_mvp_simulation.py \
-  --provider FMCSA \
-  --fmcsa-source implementer-adapter \
-  --mc-number 498282 \
-  --policy-profile-id US_FMCSA_BALANCED_V1 \
-  --risk-tier 1 \
-  --response Accept \
-  --verification-status Success
-```
-
-Expected success line:
-- `Booking completed successfully ...`
-
-If verification fails in adapter mode, that is expected when authority/insurance checks fail for the MC or the adapter fails closed.
-
-Degraded verification policy demo (provisional/hold path):
-
-```bash
-python3 faxp_mvp_simulation.py \
-  --provider FMCSA \
-  --fmcsa-source implementer-adapter \
-  --mc-number 498282 \
-  --policy-profile-id US_FMCSA_BALANCED_V1 \
-  --risk-tier 2 \
-  --exception-approved \
-  --exception-approval-ref APPROVAL-DEMO-001 \
-  --response Accept \
-  --verification-status Success
-```
-
-Hosted FMCSA adapter simulation path:
-
-```bash
-python3 faxp_mvp_simulation.py \
-  --provider FMCSA \
-  --fmcsa-source implementer-adapter \
-  --mc-number 498282 \
-  --response Accept \
-  --verification-status Success
-```
-
-### 3) Run the Streamlit Demo (Local)
+Run Streamlit demo:
 
 ```bash
 ./scripts/run_secure_demo.sh streamlit
 ```
 
-Open:
-- `http://localhost:8501`
+## Conformance and Governance
 
-Known-good preset:
-1. `Quick Preset` -> `MockBiometric success`
-2. `Apply Preset`
-3. `Run NewLoad -> Bid Flow`
+Core docs:
+- `docs/INDEX.md`
+- `docs/governance/GOVERNANCE_INDEX.json`
+- `docs/governance/RELEASE_READINESS_CHECKLIST.md`
+- `conformance/README.md`
 
-Expected:
-- `Status: Booking completed.`
-- `VerifiedBadge: Premium`
-- `Validation Errors: 0`
+Run full conformance suite:
 
-Policy controls in sidebar:
-- `Verification Policy Profile` (`US_FMCSA_BALANCED_V1`, `US_FMCSA_SOFTHOLD_V1`, or `US_FMCSA_STRICT_V1`)
+```bash
+python3 conformance/run_all_checks.py --output /tmp/faxp_conformance_suite_report.json
+```
+
+## Interop
+
+A2A quick checks:
+
+```bash
+./scripts/run_a2a_conformance.sh
+```
+
+MCP quick checks:
+
+```bash
+./scripts/run_mcp_conformance.sh
+```
+
+## Security and Reporting
+
+Security policy and vulnerability reporting:
+- `SECURITY.md`
+
+## Contributing
+
+Contributor guide:
+- `CONTRIBUTING.md`
 - `Risk Tier` (`0-3`)
 - `Exception Approved` + `Exception Approval Ref`
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are prioritized for:
+- `main`
+- the latest tagged stable release
+- the active release candidate branch/tag (if one is in soak)
+
+Older tags may not receive fixes.
+
+## Reporting a Vulnerability
+
+Do not open public issues for suspected vulnerabilities.
+
+Report privately to:
+- `info@faxp.org`
+
+Include:
+- affected file(s) and commit/tag
+- reproduction steps
+- impact assessment
+- proof-of-concept details (if available)
+
+## Response Targets
+
+- Acknowledgement: within 72 hours
+- Initial triage: within 7 days
+- Coordinated remediation plan: within 14 days for validated high-severity issues
+
+Target timelines may be adjusted based on severity, exploitability, and operational risk.
+
+## Disclosure Process
+
+1. Confirm issue validity and severity.
+2. Prepare and test a fix.
+3. Coordinate disclosure timing with reporter.
+4. Publish release notes and remediation guidance.
+
+## Security Baseline in This Repository
+
+- Signed envelopes and verifier attestations.
+- Replay and TTL enforcement.
+- Role-capability policy validation.
+- Conformance and governance release gates in CI.
+
+Operational verifier hosting and credentials remain outside protocol-core responsibilities.


### PR DESCRIPTION
## Summary
Prepares repository for public contributors by adding clear project scope docs, security reporting policy, and GitHub contribution templates.

## Changes
- Rewrite root README for public-facing scope and quickstart clarity.
- Add SECURITY.md with vulnerability reporting and disclosure process.
- Add CONTRIBUTING.md with workflow, scope, RFC, and validation expectations.
- Add GitHub templates:
  - pull request template
  - bug report issue template
  - feature request issue template
  - CODEOWNERS baseline

## Validation
- `./.venv/bin/python tests/run_governance_index.py`
- `./.venv/bin/python tests/run_release_readiness.py`
