### PR TITLE
Draft operational handoff metadata RFC and scope guardrails

### DIFF
--- a/docs/governance/SCOPE_GUARDRAILS.md
+++ b/docs/governance/SCOPE_GUARDRAILS.md
@@ -36,6 +36,7 @@ These guardrails prevent scope creep into dispatch operations, tracking operatio
 ## Clarification
 - `DispatchAuthorization` in `ExecutionReport` is currently treated as a booking-time policy gate only.
 - It must not expand into dispatch orchestration message types or downstream dispatch lifecycle state in protocol core.
+- Optional post-booking operational handoff metadata may describe neutral routing intent only; it must not carry dispatch packet content or operational execution state.
 - FAXP may enforce trusted-attestation policy and verifier admission criteria, but verifier execution remains implementer-hosted.
 - FAXP does not determine regulatory eligibility; it authenticates protocol messages and can transport optional verifier evidence.
 - Verification ownership boundaries are documented in `docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`.

--- a/docs/rfc/RFC-v0.3-operational-handoff-metadata.md
+++ b/docs/rfc/RFC-v0.3-operational-handoff-metadata.md
@@ -1,0 +1,100 @@
+# RFC: v0.3 Operational Handoff Metadata
+
+## RFC Metadata
+- RFC ID: `rfc-v0.3-operational-handoff-metadata`
+- Title: `Define neutral post-booking operational handoff metadata`
+- Author(s): `FAXP Governance Working Group`
+- Status: `Draft`
+- Target Version: `v0.3.x`
+- Created: `2026-02-27`
+- Last Updated: `2026-02-27`
+
+## Summary
+Define an optional, neutral metadata contract that allows a receiving system to route a completed booking into the correct downstream operational workflow after `ExecutionReport`, without expanding FAXP into dispatch, document custody, or settlement workflows.
+
+## Motivation
+FAXP intentionally ends at booking confirmation. In practice, the parties still need a clean handoff into their own TMS, portal, operations agent, or human workflow to complete dispatch, rate confirmation, onboarding/setup exceptions, and other downstream actions.
+
+Without a standard handoff shape, each implementation must invent its own post-booking routing conventions. This creates unnecessary integration friction even when the booking itself is already standardized.
+
+## Scope Gate (Required)
+- Scope Classification: `In-Scope`
+- Protocol-Core Impacted Files:
+  - None required for base proposal.
+  - Optional schema/runtime changes only if this RFC is later accepted.
+- Message Types Added/Changed:
+  - No new message types required.
+  - `ExecutionReport` may later carry optional handoff metadata if approved.
+- Schema Fields Added/Changed:
+  - Planning target only: optional `OperationalHandoff` or equivalent metadata object.
+
+### Required Checks
+- [x] This RFC stays within booking-plane protocol scope.
+- [x] No new dispatch-orchestration message or state model is introduced.
+- [x] No new tracking lifecycle model (telematics/POD/BOL custody) is introduced.
+- [x] No new settlement lifecycle model (invoice/payment/remittance/factoring) is introduced.
+- [x] If `Scope Expansion`, this RFC includes full security/compliance/interoperability/migration analysis and explicit approval request.
+
+## Detailed Design
+1. Keep `ExecutionReport` as the booking confirmation boundary.
+2. Define optional neutral handoff metadata for downstream routing only.
+3. Candidate field set:
+   - `OperationalReference`
+   - `SystemOfRecordType`
+   - `SystemOfRecordRef`
+   - `HandoffEndpointType`
+   - `HandoffEndpointRef`
+   - `SupportedHandoffActions`
+   - `SetupStatus`
+4. Intended use:
+   - tell the receiving side which internal/external workflow to invoke next,
+   - identify the correct system-of-record reference,
+   - surface whether setup/onboarding is already complete or still required.
+5. Strict non-goals:
+   - no dispatch packet payloads,
+   - no appointment details lifecycle,
+   - no rate confirmation document transport,
+   - no financial/accounting workflow states.
+
+## Security Considerations
+1. Handoff metadata must remain signed as part of the message envelope if added to protocol messages.
+2. Metadata should be opaque/neutral where possible to avoid overexposing internal operational details.
+3. Unsupported or malformed handoff metadata must fail closed or be ignored by local policy without altering booking validity.
+4. Handoff routing references must not be treated as proof of operational execution.
+
+## Compliance and Governance Considerations
+1. Preserve vendor neutrality and transport neutrality.
+2. Keep handoff metadata as routing intent, not operational truth.
+3. Ensure governance docs explicitly preserve dispatch, document custody, and settlement boundaries.
+4. If later implemented, require conformance profile/tests proving handoff metadata does not mutate booking-plane scope.
+
+## Backward Compatibility
+1. Metadata must be optional and additive.
+2. Existing `ExecutionReport` payloads must remain valid without handoff fields.
+3. Implementations not using handoff metadata must remain fully conformant.
+
+## Test Plan (If Implemented Later)
+1. Schema tests for optional handoff object shape and allowed values.
+2. Runtime tests proving malformed metadata does not create implicit dispatch states.
+3. Conformance checks ensuring handoff object remains routing-only and does not transport dispatch content.
+
+## Rollout Plan
+1. Governance review and acceptance.
+2. Decide whether handoff metadata belongs in `ExecutionReport`, capability profiles, or both.
+3. If accepted, add optional profile/schema contract and tests.
+4. Keep all operational execution artifacts external to FAXP core.
+
+## Alternatives Considered
+1. Put dispatch details directly into FAXP: rejected as out of scope.
+2. Leave handoff entirely undefined: rejected due to interoperability friction.
+3. Use vendor-specific portal/TMS conventions only: rejected due to lock-in and inconsistent automation behavior.
+
+## Open Questions
+1. Should handoff metadata live only in `ExecutionReport`, or also in party capability/profile artifacts?
+2. Should `SetupStatus` be fully standardized or left implementation-defined?
+3. Should `SupportedHandoffActions` use a canonical small enum or remain profile-driven?
+
+## Approval
+- Maintainer Approval:
+- Governance Approval (if required):
+- Date:

--- a/docs/roadmap/V0_3_0_RFC_BACKLOG.md
+++ b/docs/roadmap/V0_3_0_RFC_BACKLOG.md
@@ -107,3 +107,11 @@ These remain scope expansions and require separate governance track beyond curre
 - Target: `v0.3.x`
 - Notes: Optional metadata only; no FAXP-hosted oracle services and no mandatory vendor coupling.
 - Draft file: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-rate-oracle-extension.md`
+
+11. `RFC-v0.3-operational-handoff-metadata`
+- Goal: Define optional neutral post-booking handoff metadata so systems can route completed bookings into the correct downstream ops workflow without moving dispatch into protocol core.
+- Scope class: `In-Scope`
+- Status: `Draft` (Deferred to v0.3.x)
+- Target: `v0.3.x`
+- Notes: Routing intent only; no dispatch packet content, appointment lifecycle, document custody, or settlement workflow state.
+- Draft file: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-operational-handoff-metadata.md`


### PR DESCRIPTION
## Summary
- adds planning-only RFC for neutral post-booking operational handoff metadata
- adds RFC backlog entry for operational handoff metadata
- clarifies scope guardrails so routing intent is allowed but dispatch content/state remains out of core

## Scope
- docs/governance only
- no runtime or schema behavior changes
- no expansion into dispatch, document custody, or settlement
