### PR TITLE
Clean up public README and remove internal deployment sprawl

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,28 @@
 
 FAXP (Freight Agent eXchange Protocol) is an open, vendor-neutral booking-plane protocol for agent-to-agent freight matching and booking confirmation.
 
+FAXP standardizes how freight agents exchange booking messages across systems without requiring vendor lock-in.
+
+FAXP does not determine regulatory eligibility; it authenticates protocol messages and can transport optional verifier evidence.
+
 ## Scope
 
 In scope:
-- Agent message envelopes, signatures, replay/TTL checks, and validation.
-- Booking workflow message types:
+- agent message envelopes, signatures, replay/TTL checks, and validation
+- booking workflow message types:
   - `NewLoad`, `LoadSearch`
   - `NewTruck`, `TruckSearch`
   - `BidRequest`, `BidResponse`
   - `ExecutionReport`, `AmendRequest`
-- Optional verification evidence transport and policy decisions that affect booking outcome.
-- Conformance profiles, certification artifacts, and governance checks.
+- optional verifier evidence transport and booking-policy decisions
+- conformance profiles, certification artifacts, and governance checks
 
 Out of scope:
-- Dispatch execution.
-- Telematics and tracking lifecycle.
-- POD/BOL custody lifecycle.
-- Invoicing, remittance, payment rails, and settlement operations.
-- FAXP-hosted verifier operations.
+- dispatch execution
+- telematics and tracking lifecycle
+- POD/BOL custody lifecycle
+- invoicing, remittance, payment rails, and settlement operations
+- FAXP-hosted verifier operations
 
 Canonical boundary docs:
 - `docs/governance/SCOPE_GUARDRAILS.md`
@@ -27,16 +31,18 @@ Canonical boundary docs:
 
 ## Repository Contents
 
-- `faxp_mvp_simulation.py`: CLI protocol simulation.
-- `streamlit_app.py`: interactive demo.
-- `conformance/`: profiles, artifacts, and full conformance harness.
-- `docs/`: governance, RFCs, roadmap, and release notes.
-- `adapter/`: adapter interface and reference implementation components.
+- `faxp_mvp_simulation.py`: CLI protocol simulation and validation runtime
+- `streamlit_app.py`: interactive demo
+- `conformance/`: profiles, artifacts, and conformance harness
+- `docs/`: governance, RFCs, roadmap, and release material
+- `adapter/`: adapter interface and reference implementation components
+- `scripts/`: security, smoke, and interoperability helper scripts
 
 ## Quick Start
 
+Create a virtual environment and install dependencies:
+
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FIX-F
 python3 -m venv .venv
 source .venv/bin/activate
 python3 -m pip install -U pip
@@ -46,19 +52,19 @@ python3 -m pip install -r requirements.txt
 Generate local security material:
 
 ```bash
-./scripts/generate_faxp_keys.sh /Users/zglitch009/.faxp-secrets
+./scripts/generate_faxp_keys.sh "$HOME/.faxp-secrets"
 set -a
-source /Users/zglitch009/.faxp-secrets/security.env.local
+source "$HOME/.faxp-secrets/security.env.local"
 set +a
 ```
 
-Run release smoke locally:
+Run the local release smoke check:
 
 ```bash
 ./scripts/run_release_smoke_local.sh
 ```
 
-Run Streamlit demo:
+Run the Streamlit demo:
 
 ```bash
 ./scripts/run_secure_demo.sh streamlit
@@ -72,7 +78,7 @@ Core docs:
 - `docs/governance/RELEASE_READINESS_CHECKLIST.md`
 - `conformance/README.md`
 
-Run full conformance suite:
+Run the full conformance suite:
 
 ```bash
 python3 conformance/run_all_checks.py --output /tmp/faxp_conformance_suite_report.json
@@ -80,280 +86,49 @@ python3 conformance/run_all_checks.py --output /tmp/faxp_conformance_suite_repor
 
 ## Interop
 
-A2A quick checks:
+Run A2A compatibility checks:
 
 ```bash
 ./scripts/run_a2a_conformance.sh
 ```
 
-MCP quick checks:
+Run MCP compatibility checks:
 
 ```bash
 ./scripts/run_mcp_conformance.sh
 ```
 
-## Security and Reporting
+## Deployment and Operational Docs
+
+Operational deployment details are kept in dedicated docs, not in this top-level README.
+
+Useful starting points:
+- `docs/governance/CERTIFICATION_PLAYBOOK.md`
+- `docs/governance/VENDOR_DIRECT_CERTIFICATION_RUNBOOK.md`
+- `deploy/vultr/README.md`
+
+## Security
 
 Security policy and vulnerability reporting:
 - `SECURITY.md`
 
 ## Contributing
 
-Contributor guide:
+Contributor workflow and scope expectations:
 - `CONTRIBUTING.md`
-- `Risk Tier` (`0-3`)
-- `Exception Approved` + `Exception Approval Ref`
 
-### 4) Streamlit Cloud Deployment
+Before opening a PR:
+1. read the scope guardrails
+2. keep changes within booking-plane and governance boundaries
+3. run the relevant local checks
 
-Set app entrypoint:
-- `streamlit_app.py`
+## Current Status
 
-Set secrets in Streamlit Cloud.
+FAXP currently focuses on the booking plane:
 
-Minimum cloud-safe secrets:
-```toml
-FAXP_APP_MODE="prod"
-FAXP_CLOUD_SAFE_MODE="1"
-FAXP_STREAMLIT_ACCESS_KEY="set-a-strong-random-string"
-FAXP_MAX_VERIFICATIONS_PER_HOUR="30"
-FAXP_AUTH_MAX_FAILURES="5"
-FAXP_AUTH_LOCKOUT_SECONDS="300"
-```
+1. opportunity discovery
+2. bid and counter exchange
+3. optional verifier evidence handling
+4. booking confirmation via `ExecutionReport`
 
-Recommended hosted FMCSA adapter secrets:
-```toml
-FAXP_FMCSA_ADAPTER_BASE_URL="https://your-hosted-verifier.example/v1/fmcsa/verify"
-FAXP_FMCSA_ADAPTER_AUTH_TOKEN="your_adapter_access_token"
-FAXP_FMCSA_ADAPTER_TIMEOUT_SECONDS="10"
-FAXP_FMCSA_ADAPTER_REQUIRE_SIGNED_WRAPPER="1"
-FAXP_FMCSA_ADAPTER_SIGN_REQUESTS="1"
-FAXP_FMCSA_ADAPTER_REQUEST_SIGNING_KEYS="adapter-req-2026-02:your_adapter_request_hmac"
-FAXP_FMCSA_ADAPTER_REQUEST_SIGNING_ACTIVE_KEY_ID="adapter-req-2026-02"
-FAXP_ENFORCE_TRUSTED_VERIFIER_REGISTRY="1"
-# Optional override (runtime falls back to conformance/trusted_verifier_registry.sample.json)
-# FAXP_TRUSTED_VERIFIER_REGISTRY='{"registryVersion":"1.0.0","entries":[...]}'
-```
-
-Notes:
-- Non-local mode requires `implementer-adapter` or `vendor-direct` compliance verification and fails closed if the adapter URL is missing.
-- `hosted-adapter` remains accepted as a backward-compatible alias for `implementer-adapter`.
-- Non-local mode enforces trusted verifier registry validation on verification results.
-- Access key is enforced when `FAXP_APP_MODE` is non-local.
-
-### 4.1) Hosted FMCSA Adapter Deployment (Vultr)
-
-Vultr deployment artifacts:
-
-- `/Users/zglitch009/projects/logistics-ai/FAXP/fmcsa_adapter_server.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/deploy/vultr/README.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/deploy/vultr/fmcsa_adapter.env.example`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/deploy/vultr/fmcsa-adapter.service`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/deploy/vultr/Caddyfile.fmcsa-adapter`
-
-### 5) Security/Health Checks
-
-Run security gate:
-
-```bash
-./scripts/security_gate.sh /Users/zglitch009/.faxp-secrets/security.env.local
-```
-
-Run incident drill:
-
-```bash
-./scripts/incident_drill.sh /Users/zglitch009/.faxp-secrets/security.env.local
-```
-
-Run self-test mode:
-
-```bash
-./scripts/run_secure_demo.sh check
-```
-
-### 6) Regression Checks
-
-Parser fixture checks:
-
-```bash
-python3 tests/run_fmcsa_parser_fixtures.py
-```
-
-Streamlit state guard checks:
-
-```bash
-python3 tests/run_streamlit_state_logic.py
-```
-
-Schema compatibility checks (`v0.1.1` and `v0.2`):
-
-```bash
-python3 tests/run_schema_compatibility.py
-```
-
-Certification/profile artifact checks:
-
-```bash
-python3 tests/run_certification_artifacts.py
-```
-
-This check now validates:
-
-- verification policy profile schemas,
-- certification registry schemas,
-- adapter self-attestation payload digest and HMAC signature,
-- registry/profile consistency (ID, tier, hosting model, supported profiles, key ID).
-
-Verification policy decision checks:
-
-```bash
-python3 tests/run_policy_decisions.py
-```
-
-Attestation generator checks:
-
-```bash
-python3 tests/run_generate_attestation.py
-```
-
-Conformance bundle checks:
-
-```bash
-python3 tests/run_conformance_bundle.py \
-  --profile conformance/adapter_profile.sample.json \
-  --registry-entry conformance/certification_registry.sample.json \
-  --keyring conformance/attestation_keys.sample.json \
-  --output /tmp/faxp_conformance_report.json
-```
-
-Adapter test profile checks:
-
-```bash
-python3 tests/run_adapter_test_profile.py
-```
-
-Submission manifest bundle checks:
-
-```bash
-python3 tests/run_submission_manifest.py
-```
-
-Submission manifest create helper checks:
-
-```bash
-python3 tests/run_create_submission_manifest.py
-```
-
-Create signed submission manifest:
-
-```bash
-python3 conformance/create_submission_manifest.py \
-  --template conformance/submission_manifest.sample.json \
-  --keyring conformance/submission_manifest_keys.sample.json \
-  --kid faxp-submission-kid-2026q1 \
-  --output /tmp/faxp_submission_manifest.signed.json
-```
-
-Key lifecycle policy checks:
-
-```bash
-python3 tests/run_key_lifecycle_policy.py
-```
-
-Conformance suite orchestrator check:
-
-```bash
-python3 tests/run_conformance_suite.py
-```
-
-Run full conformance suite and emit one report:
-
-```bash
-python3 conformance/run_all_checks.py \
-  --output /tmp/faxp_conformance_suite_report.json
-```
-
-Registry operations artifact checks:
-
-```bash
-python3 tests/run_registry_ops_artifacts.py
-```
-
-Registry apply tool checks:
-
-```bash
-python3 tests/run_apply_registry_update.py
-```
-
-Registry update create helper checks:
-
-```bash
-python3 tests/run_create_registry_update.py
-```
-
-Create signed registry update request:
-
-```bash
-python3 conformance/create_registry_update.py \
-  --template conformance/registry_update.sample.json \
-  --keyring conformance/registry_update_keys.sample.json \
-  --kid faxp-regops-kid-2026q1 \
-  --output /tmp/faxp_registry_update.signed.json
-```
-
-Apply registry update request and write output:
-
-```bash
-python3 conformance/apply_registry_update.py \
-  --request conformance/registry_update.sample.json \
-  --keyring conformance/registry_update_keys.sample.json \
-  --output /tmp/faxp_registry_after_update.json
-```
-
-Verifier translator checks:
-
-```bash
-python3 tests/run_verifier_translator.py
-```
-
-Regenerate adapter self-attestation fields (digest/signature):
-
-```bash
-python3 conformance/generate_attestation.py \
-  --profile conformance/adapter_profile.sample.json \
-  --keyring conformance/attestation_keys.sample.json \
-  --kid faxp-lab-selfattest-2026q1 \
-  --in-place
-```
-
-Quickstart onboarding bundle (templates + attestation + report):
-
-```bash
-bash conformance/quickstart/make_conformance_bundle.sh
-```
-
-### 7) Troubleshooting
-
-`streamlit: command not found`
-- Use venv binary: `./.venv/bin/streamlit run streamlit_app.py`
-
-`Missing active ED25519 private key for sender`
-- Confirm `FAXP_AGENT_KEY_REGISTRY_FILE` points to your generated key registry.
-- Re-run `./scripts/generate_faxp_keys.sh /Users/zglitch009/.faxp-secrets`.
-
-`Verifier signature key ID missing`
-- Ensure verifier signing vars exist in your loaded env.
-- Confirm `FAXP_VERIFIER_ED25519_ACTIVE_KEY_ID` matches a key in verifier key ring.
-
-`repository/branch/file does not exist` in Streamlit deploy
-- Verify repo path, branch `main`, and main file `streamlit_app.py`.
-- Re-authorize GitHub app permissions for Streamlit if repo visibility changed.
-
-`Process completed with exit code 1` in CI
-- Open failing job logs, then run the same script locally from this runbook section 6.
-
-### 8) Protocol Versions
-
-- Current runtime protocol in simulation: `0.1.1`.
-- Added schema compatibility track for `0.2.0`: `faxp.v0.2.schema.json`.
-- CI enforces backward compatibility checks between `0.1.1` and `0.2.0`.
+Downstream dispatch, onboarding, rate confirmation, and settlement remain external to FAXP core and are expected to run in the participant's TMS, portal, ops agent, or human workflow.


### PR DESCRIPTION
## Summary
- replaces the root README with a clean public-facing project overview
- keeps scope boundaries explicit
- removes machine-specific paths and internal deployment sprawl from the top-level entry point
- pushes operational details down into dedicated docs where they belong

## Scope
- documentation only
- no runtime or schema behavior changes
