### PR TITLE
Normalize doc paths to repo-relative references

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -412,4 +412,4 @@ result = translate_verifier_payload(
 
 Production note:
 
-- `/Users/zglitch009/projects/logistics-ai/FAXP/fmcsa_adapter_server.py` now routes FMCSA lookup output through this translator wrapper by default before signing responses.
+- `fmcsa_adapter_server.py` now routes FMCSA lookup output through this translator wrapper by default before signing responses.

--- a/docs/adapters/ADAPTER_IMPLEMENTER_HANDOFF.md
+++ b/docs/adapters/ADAPTER_IMPLEMENTER_HANDOFF.md
@@ -3,12 +3,12 @@
 This checklist is the implementation handoff for any builder to host an FMCSA adapter while staying FAXP-conformant.
 
 Primary contract references:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/adapter/INTERFACE.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/CERTIFICATION_PLAYBOOK.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/REGISTRY_OPERATIONS_RUNBOOK.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/adapter_test_profile.schema.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/fmcsa_adapter_test_profile.v1.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/submission_manifest.schema.json`
+- `adapter/INTERFACE.md`
+- `docs/governance/CERTIFICATION_PLAYBOOK.md`
+- `docs/governance/REGISTRY_OPERATIONS_RUNBOOK.md`
+- `conformance/adapter_test_profile.schema.json`
+- `conformance/fmcsa_adapter_test_profile.v1.json`
+- `conformance/submission_manifest.schema.json`
 
 ## 1) Build Scope
 

--- a/docs/governance/CERTIFICATION_PLAYBOOK.md
+++ b/docs/governance/CERTIFICATION_PLAYBOOK.md
@@ -7,7 +7,7 @@ Purpose:
 - Standardize certification intake for any builder-hosted adapter.
 - Provide deterministic pass/fail checks before registry acceptance.
 - Responsibility boundary reference:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`
+  - `docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`
 
 ## 1) Certification Tiers
 
@@ -31,7 +31,7 @@ Purpose:
 FAXP also maintains a v2 certification profile artifact for builder-hosted adapter certification maturity.
 
 Reference artifact:
-- `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/adapter_certification_profile.v2.json`
+- `conformance/adapter_certification_profile.v2.json`
 
 v2 additions:
 1. explicit evidence classes:
@@ -61,30 +61,30 @@ Required bundle files:
 6. Submission manifest JSON (schema valid; references all files above).
 
 Reference paths:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/adapter_profile.schema.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/certification_registry.schema.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/adapter_test_profile.schema.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/submission_manifest.schema.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/submission_manifest_keys.sample.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/create_submission_manifest.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/key_lifecycle_policy.schema.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/key_lifecycle_policy.sample.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/registry_update.schema.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/registry_update_keys.sample.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/create_registry_update.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/REGISTRY_OPERATIONS_RUNBOOK.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/REGISTRY_CHANGELOG_POLICY.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/TRUSTED_VERIFIER_ADMISSION_REQUIREMENTS.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/TRUST_MODEL.md`
-- `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/GOVERNANCE_INDEX.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/RELEASE_READINESS_CHECKLIST.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/apply_registry_update.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/trusted_verifier_registry.sample.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/vendor_direct_verifier_profile.v1.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/trust_profile.v1.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/accessorial_terms_profile.v1.json`
+- `conformance/adapter_profile.schema.json`
+- `conformance/certification_registry.schema.json`
+- `conformance/adapter_test_profile.schema.json`
+- `conformance/submission_manifest.schema.json`
+- `conformance/submission_manifest_keys.sample.json`
+- `conformance/create_submission_manifest.py`
+- `conformance/key_lifecycle_policy.schema.json`
+- `conformance/key_lifecycle_policy.sample.json`
+- `conformance/registry_update.schema.json`
+- `conformance/registry_update_keys.sample.json`
+- `conformance/create_registry_update.py`
+- `docs/governance/REGISTRY_OPERATIONS_RUNBOOK.md`
+- `docs/governance/REGISTRY_CHANGELOG_POLICY.md`
+- `docs/governance/TRUSTED_VERIFIER_ADMISSION_REQUIREMENTS.md`
+- `docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
+- `docs/governance/TRUST_MODEL.md`
+- `docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`
+- `docs/governance/GOVERNANCE_INDEX.json`
+- `docs/governance/RELEASE_READINESS_CHECKLIST.md`
+- `conformance/apply_registry_update.py`
+- `conformance/trusted_verifier_registry.sample.json`
+- `conformance/vendor_direct_verifier_profile.v1.json`
+- `conformance/trust_profile.v1.json`
+- `conformance/accessorial_terms_profile.v1.json`
 
 ## 3) Intake Workflow
 
@@ -116,9 +116,9 @@ Reference paths:
 5. If all checks pass, registry entry is accepted/updated.
 6. If checks fail, submission is rejected with explicit failing check IDs.
 7. Reviewer emits a decision artifact using:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/CERTIFICATION_DECISION_RECORD_TEMPLATE.md`
+- `docs/governance/CERTIFICATION_DECISION_RECORD_TEMPLATE.md`
 8. Reviewer follows decision-record operations runbook:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/DECISION_RECORDS_RUNBOOK.md`
+- `docs/governance/DECISION_RECORDS_RUNBOOK.md`
 
 ## 4) Pass/Fail Gates
 
@@ -132,7 +132,7 @@ Mandatory gates:
 - supported profile alignment.
 4. Conformance report pass status for requested tier (`Conformant` or `TrustedProduction`).
 5. Policy profile conformance synchronization:
-- Normative profile matrix in `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/POLICY_PROFILES.md` is valid.
+- Normative profile matrix in `docs/governance/POLICY_PROFILES.md` is valid.
 - All three degraded modes are represented by active profile artifacts:
   - `HardBlock`
   - `SoftHold`
@@ -229,7 +229,7 @@ Required local checks before submission:
 Implementers that claim A2A and/or MCP interoperability maturity must back that claim with objective evidence.
 
 Reference artifact:
-- `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/interop_maturity_profile.v1.json`
+- `conformance/interop_maturity_profile.v1.json`
 
 Rules:
 1. Interop maturity claims are optional and must not imply mandatory FAXP core dependencies on A2A or MCP.

--- a/docs/governance/DECISION_RECORDS_RUNBOOK.md
+++ b/docs/governance/DECISION_RECORDS_RUNBOOK.md
@@ -8,9 +8,9 @@ This runbook defines how FAXP certification decision artifacts are created, revi
 - Prevent ambiguous approval/rejection outcomes.
 
 ## Source Contract
-- Template: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/CERTIFICATION_DECISION_RECORD_TEMPLATE.md`
-- Artifact check: `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_decision_record_artifacts.py`
-- Template check: `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_decision_record_template.py`
+- Template: `docs/governance/CERTIFICATION_DECISION_RECORD_TEMPLATE.md`
+- Artifact check: `tests/run_decision_record_artifacts.py`
+- Template check: `tests/run_decision_record_template.py`
 
 ## Artifact Location
 - Store decision records in `conformance/`.

--- a/docs/governance/DECISION_RECORD_a2a-bridge-translator-only_2026-02-23.md
+++ b/docs/governance/DECISION_RECORD_a2a-bridge-translator-only_2026-02-23.md
@@ -23,9 +23,9 @@ FAXP core protocol envelopes, message types, and validation/security controls re
 - Aligns with open-standard neutrality and builder-operated deployment model.
 
 ## Normative Artifacts
-- A2A profile: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/A2A_COMPATIBILITY_PROFILE.md`
-- Translator contract: `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/a2a_translator_contract.json`
-- Conformance check: `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_a2a_profile_check.py`
+- A2A profile: `docs/interop/A2A_COMPATIBILITY_PROFILE.md`
+- Translator contract: `conformance/a2a_translator_contract.json`
+- Conformance check: `tests/run_a2a_profile_check.py`
 
 ## Guardrails
 - Any proposal to embed A2A objects directly into FAXP core schemas or envelope rules requires a new RFC and governance vote.
@@ -34,4 +34,4 @@ FAXP core protocol envelopes, message types, and validation/security controls re
 ## Rollout
 - Effective immediately for v0.2 planning and onward.
 - Included in conformance suite via `a2a_profile` check.
-- Upstream monitoring is handled by `/Users/zglitch009/projects/logistics-ai/FAXP/.github/workflows/a2a-watch.yml` and `/Users/zglitch009/projects/logistics-ai/FAXP/scripts/check_a2a_upstream.py`.
+- Upstream monitoring is handled by `.github/workflows/a2a-watch.yml` and `scripts/check_a2a_upstream.py`.

--- a/docs/governance/DECISION_RECORD_a2a-mcp-interop-boundary_2026-02-23.md
+++ b/docs/governance/DECISION_RECORD_a2a-mcp-interop-boundary_2026-02-23.md
@@ -24,23 +24,23 @@ FAXP core protocol remains independent from A2A and MCP runtime dependencies.
 - Ensures interop evolution is auditable via profile + contract + watch governance.
 
 ## Normative Artifacts
-- A2A profile: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/A2A_COMPATIBILITY_PROFILE.md`
-- A2A contract: `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/a2a_translator_contract.json`
-- A2A watch runbook: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/A2A_CHANGE_MANAGEMENT.md`
-- A2A tracking: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/A2A_UPSTREAM_TRACKING.json`
-- MCP profile: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/MCP_COMPATIBILITY_PROFILE.md`
-- MCP contract: `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/mcp_tooling_contract.json`
-- MCP watch runbook: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/MCP_CHANGE_MANAGEMENT.md`
-- MCP tracking: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/MCP_UPSTREAM_TRACKING.json`
+- A2A profile: `docs/interop/A2A_COMPATIBILITY_PROFILE.md`
+- A2A contract: `conformance/a2a_translator_contract.json`
+- A2A watch runbook: `docs/interop/A2A_CHANGE_MANAGEMENT.md`
+- A2A tracking: `docs/interop/A2A_UPSTREAM_TRACKING.json`
+- MCP profile: `docs/interop/MCP_COMPATIBILITY_PROFILE.md`
+- MCP contract: `conformance/mcp_tooling_contract.json`
+- MCP watch runbook: `docs/interop/MCP_CHANGE_MANAGEMENT.md`
+- MCP tracking: `docs/interop/MCP_UPSTREAM_TRACKING.json`
 
 ## Required Checks
-- `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_a2a_profile_check.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_a2a_roundtrip_translation.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_a2a_watch_artifacts.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_mcp_profile_check.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_mcp_watch_artifacts.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/scripts/run_a2a_conformance.sh`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/scripts/run_mcp_conformance.sh`
+- `tests/run_a2a_profile_check.py`
+- `tests/run_a2a_roundtrip_translation.py`
+- `tests/run_a2a_watch_artifacts.py`
+- `tests/run_mcp_profile_check.py`
+- `tests/run_mcp_watch_artifacts.py`
+- `scripts/run_a2a_conformance.sh`
+- `scripts/run_mcp_conformance.sh`
 
 ## Guardrails
 - Any proposal to add mandatory A2A or MCP dependencies in FAXP core requires a new RFC and governance vote.

--- a/docs/governance/REGISTRY_ADMISSION_POLICY.md
+++ b/docs/governance/REGISTRY_ADMISSION_POLICY.md
@@ -3,7 +3,7 @@
 This policy defines objective criteria for registry entry admission, renewal, and non-active status handling.
 
 ## Scope
-- Applies to certification registry artifacts under `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/`.
+- Applies to certification registry artifacts under `conformance/`.
 - Applies to admission and renewal decisions represented in registry metadata.
 - Does not define runtime booking behavior or adapter hosting operations.
 

--- a/docs/governance/TRUST_MODEL.md
+++ b/docs/governance/TRUST_MODEL.md
@@ -34,9 +34,9 @@ Notes:
 5. Fail closed on verifier errors or missing trust evidence.
 
 ## Governance Artifacts
-- Machine-readable trust profile: `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/trust_profile.v1.json`
-- Verifier admission policy: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/TRUSTED_VERIFIER_ADMISSION_REQUIREMENTS.md`
-- Verification boundary policy: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`
+- Machine-readable trust profile: `conformance/trust_profile.v1.json`
+- Verifier admission policy: `docs/governance/TRUSTED_VERIFIER_ADMISSION_REQUIREMENTS.md`
+- Verification boundary policy: `docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`
 
 ## Certification Impact
 Implementers are certified against trust conformance evidence, not against vendor preference.

--- a/docs/interop/A2A_CHANGE_MANAGEMENT.md
+++ b/docs/interop/A2A_CHANGE_MANAGEMENT.md
@@ -8,10 +8,10 @@ This runbook defines how FAXP tracks upstream A2A changes while keeping FAXP cor
 - Keep A2A support in the translator/profile layer only.
 
 ## Source of Truth
-- Compatibility profile: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/A2A_COMPATIBILITY_PROFILE.md`
-- Translator contract: `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/a2a_translator_contract.json`
-- Round-trip fixtures: `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/a2a_roundtrip_fixtures.json`
-- Tracking config: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/A2A_UPSTREAM_TRACKING.json`
+- Compatibility profile: `docs/interop/A2A_COMPATIBILITY_PROFILE.md`
+- Translator contract: `conformance/a2a_translator_contract.json`
+- Round-trip fixtures: `conformance/a2a_roundtrip_fixtures.json`
+- Tracking config: `docs/interop/A2A_UPSTREAM_TRACKING.json`
 
 ## Weekly Process
 1. Run the watch check (automated in GitHub Actions).
@@ -26,21 +26,21 @@ This runbook defines how FAXP tracks upstream A2A changes while keeping FAXP cor
    - Merge after CI green.
 
 ## Escalation Rules
-- Any proposal that introduces A2A runtime dependency into FAXP core must go through RFC using `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC_TEMPLATE.md`.
+- Any proposal that introduces A2A runtime dependency into FAXP core must go through RFC using `docs/rfc/RFC_TEMPLATE.md`.
 - If translator parity cannot be preserved (signature/replay/TTL semantics), fail closed and do not claim compatibility.
 
 ## Builder Quickstart
 1. Pull the profile + contract + fixture artifacts into your adapter project.
 2. Implement translator behavior equivalent to:
-   - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/a2a_bridge_translator.py`
+   - `conformance/a2a_bridge_translator.py`
 3. Run one-command local checks:
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 ./scripts/run_a2a_conformance.sh
 ```
 4. Or run checks individually:
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 python3 tests/run_a2a_profile_check.py
 python3 tests/run_a2a_roundtrip_translation.py
 ```
@@ -48,7 +48,7 @@ python3 tests/run_a2a_roundtrip_translation.py
 
 ## Manual Command
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 python3 scripts/check_a2a_upstream.py \
   --tracking docs/interop/A2A_UPSTREAM_TRACKING.json \
   --output /tmp/a2a_watch_report.json \

--- a/docs/interop/MCP_CHANGE_MANAGEMENT.md
+++ b/docs/interop/MCP_CHANGE_MANAGEMENT.md
@@ -8,9 +8,9 @@ This runbook defines how FAXP tracks upstream MCP changes while keeping FAXP cor
 - Keep MCP support in the interop/tool layer only.
 
 ## Source of Truth
-- Compatibility profile: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/MCP_COMPATIBILITY_PROFILE.md`
-- Tooling contract: `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/mcp_tooling_contract.json`
-- Tracking config: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/MCP_UPSTREAM_TRACKING.json`
+- Compatibility profile: `docs/interop/MCP_COMPATIBILITY_PROFILE.md`
+- Tooling contract: `conformance/mcp_tooling_contract.json`
+- Tracking config: `docs/interop/MCP_UPSTREAM_TRACKING.json`
 
 ## Weekly Process
 1. Run the watch check (automated in GitHub Actions).
@@ -25,21 +25,21 @@ This runbook defines how FAXP tracks upstream MCP changes while keeping FAXP cor
    - Merge only after CI green.
 
 ## Escalation Rules
-- Any proposal that introduces mandatory MCP dependency into FAXP core must go through RFC using `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC_TEMPLATE.md`.
+- Any proposal that introduces mandatory MCP dependency into FAXP core must go through RFC using `docs/rfc/RFC_TEMPLATE.md`.
 - If security controls (least-privilege, allowlist, audit correlation, fail-closed) cannot be preserved, do not claim compatibility.
 
 ## Builder Quickstart
 1. Pull profile + contract artifacts into your adapter project.
 2. Run one-command local check:
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 ./scripts/run_mcp_conformance.sh
 ```
 3. Submit conformance artifacts with certification bundle.
 
 ## Manual Command
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 python3 scripts/check_mcp_upstream.py \
   --tracking docs/interop/MCP_UPSTREAM_TRACKING.json \
   --output /tmp/mcp_watch_report.json \

--- a/docs/releases/RELEASE_CANDIDATE_v0.2.0-rc.1.md
+++ b/docs/releases/RELEASE_CANDIDATE_v0.2.0-rc.1.md
@@ -13,24 +13,24 @@ Current recommendation: `GO` for RC tag based on local conformance evidence and 
 ## 2) Scope Included in RC
 
 1. Protocol simulation and schema baseline:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/faxp_mvp_simulation.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/faxp.schema.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/faxp.v0.2.schema.json`
+- `faxp_mvp_simulation.py`
+- `faxp.schema.json`
+- `faxp.v0.2.schema.json`
 
 2. Policy and governance controls:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/SCOPE_GUARDRAILS.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/POLICY_PROFILES.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/REGISTRY_ADMISSION_POLICY.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/REGISTRY_CHANGELOG_POLICY.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/CERTIFICATION_DECISION_RECORD_TEMPLATE.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/DECISION_RECORDS_RUNBOOK.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/RELEASE_READINESS_CHECKLIST.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/GOVERNANCE_INDEX.json`
+- `docs/governance/SCOPE_GUARDRAILS.md`
+- `docs/governance/POLICY_PROFILES.md`
+- `docs/governance/REGISTRY_ADMISSION_POLICY.md`
+- `docs/governance/REGISTRY_CHANGELOG_POLICY.md`
+- `docs/governance/CERTIFICATION_DECISION_RECORD_TEMPLATE.md`
+- `docs/governance/DECISION_RECORDS_RUNBOOK.md`
+- `docs/governance/RELEASE_READINESS_CHECKLIST.md`
+- `docs/governance/GOVERNANCE_INDEX.json`
 
 3. Conformance and certification artifact gates:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/run_all_checks.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_conformance_suite.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/.github/workflows/ci.yml`
+- `conformance/run_all_checks.py`
+- `tests/run_conformance_suite.py`
+- `.github/workflows/ci.yml`
 
 ## 3) Security and Trust Posture (RC Snapshot)
 
@@ -46,7 +46,7 @@ Current recommendation: `GO` for RC tag based on local conformance evidence and 
 ## 4) Conformance Evidence
 
 Local RC suite report artifact:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/reports/faxp_conformance_suite_v0.2.0-rc.1.json`
+- `conformance/reports/faxp_conformance_suite_v0.2.0-rc.1.json`
 
 Report summary:
 - `totalChecks`: `16`
@@ -58,7 +58,7 @@ Report summary:
 
 ## 5) Known Deferrals (Not in RC Scope)
 
-From `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/FAXP_DEFERRED_ITEMS.md`:
+From `docs/roadmap/FAXP_DEFERRED_ITEMS.md`:
 1. Centralized `rulesync.jsonc`-style orchestration.
 2. Lockfile-driven frozen installs for all agent tooling.
 3. CI frozen dependency/config policy gates.
@@ -70,14 +70,14 @@ From `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/FAXP_DEFERRED_IT
 Verify working tree:
 
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 git status
 ```
 
 Run release-readiness and conformance suite:
 
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 .venv/bin/python tests/run_release_readiness.py
 .venv/bin/python conformance/run_all_checks.py --output conformance/reports/faxp_conformance_suite_v0.2.0-rc.1.json --log-dir /tmp/faxp-rc1-logs
 ```
@@ -85,7 +85,7 @@ cd /Users/zglitch009/projects/logistics-ai/FAXP
 Review report summary quickly:
 
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 python3 - <<'PY'
 import json
 with open("conformance/reports/faxp_conformance_suite_v0.2.0-rc.1.json", "r", encoding="utf-8") as f:
@@ -97,7 +97,7 @@ PY
 Commit RC package artifacts:
 
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 git add docs/releases/RELEASE_CANDIDATE_v0.2.0-rc.1.md conformance/reports/faxp_conformance_suite_v0.2.0-rc.1.json
 git commit -m "Add v0.2.0-rc.1 release candidate package and conformance report"
 git push
@@ -106,7 +106,7 @@ git push
 Tag RC:
 
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 git tag -a v0.2.0-rc.1 -m "FAXP v0.2.0-rc.1"
 git push origin v0.2.0-rc.1
 ```

--- a/docs/releases/RELEASE_CANDIDATE_v0.2.0-rc.2.md
+++ b/docs/releases/RELEASE_CANDIDATE_v0.2.0-rc.2.md
@@ -14,36 +14,36 @@ This release candidate confirms:
 
 ### A2A Bridge Compatibility
 - Compatibility profile:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/A2A_COMPATIBILITY_PROFILE.md`
+  - `docs/interop/A2A_COMPATIBILITY_PROFILE.md`
 - Translator contract:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/a2a_translator_contract.json`
+  - `conformance/a2a_translator_contract.json`
 - Reference translator module:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/a2a_bridge_translator.py`
+  - `conformance/a2a_bridge_translator.py`
 
 ### Deterministic Translation Validation
 - Bidirectional round-trip checks:
   - `FAXP -> A2A -> FAXP`
   - `A2A -> FAXP -> A2A`
 - Test:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_a2a_roundtrip_translation.py`
+  - `tests/run_a2a_roundtrip_translation.py`
 - Canonical fixtures:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/a2a_roundtrip_fixtures.json`
+  - `conformance/a2a_roundtrip_fixtures.json`
 
 ### A2A Governance + Operations
 - Change management runbook:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/A2A_CHANGE_MANAGEMENT.md`
+  - `docs/interop/A2A_CHANGE_MANAGEMENT.md`
 - Upstream tracking baseline:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/A2A_UPSTREAM_TRACKING.json`
+  - `docs/interop/A2A_UPSTREAM_TRACKING.json`
 - Weekly watch workflow:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/.github/workflows/a2a-watch.yml`
+  - `.github/workflows/a2a-watch.yml`
 - Watch checker:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/scripts/check_a2a_upstream.py`
+  - `scripts/check_a2a_upstream.py`
 - Artifact test:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_a2a_watch_artifacts.py`
+  - `tests/run_a2a_watch_artifacts.py`
 
 ### Builder Usability
 - One-command A2A conformance wrapper:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/scripts/run_a2a_conformance.sh`
+  - `scripts/run_a2a_conformance.sh`
 
 ## Evidence
 
@@ -54,7 +54,7 @@ This release candidate confirms:
 - `.venv/bin/python conformance/run_all_checks.py --output /tmp/faxp_conformance_suite_report.rc2.json`
 
 ### Conformance Report Artifact
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/reports/faxp_conformance_suite_v0.2.0-rc.2.json`
+- `conformance/reports/faxp_conformance_suite_v0.2.0-rc.2.json`
 
 ## Scope Guardrail Confirmation
 This RC does **not** expand FAXP into dispatch, telematics, POD/BOL, invoicing, payment, or settlement.

--- a/docs/releases/RELEASE_CANDIDATE_v0.2.0-rc.3.md
+++ b/docs/releases/RELEASE_CANDIDATE_v0.2.0-rc.3.md
@@ -16,33 +16,33 @@ Current recommendation: `GO` for RC tag based on passing conformance and release
 ## 2) Scope Included in RC
 
 1. Governance decision artifact:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/DECISION_RECORD_a2a-mcp-interop-boundary_2026-02-23.md`
+- `docs/governance/DECISION_RECORD_a2a-mcp-interop-boundary_2026-02-23.md`
 
 2. Interop governance + tracking controls:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/A2A_CHANGE_MANAGEMENT.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/A2A_UPSTREAM_TRACKING.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/.github/workflows/a2a-watch.yml`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/scripts/check_a2a_upstream.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_a2a_watch_artifacts.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/MCP_CHANGE_MANAGEMENT.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/interop/MCP_UPSTREAM_TRACKING.json`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/.github/workflows/mcp-watch.yml`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/scripts/check_mcp_upstream.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_mcp_watch_artifacts.py`
+- `docs/interop/A2A_CHANGE_MANAGEMENT.md`
+- `docs/interop/A2A_UPSTREAM_TRACKING.json`
+- `.github/workflows/a2a-watch.yml`
+- `scripts/check_a2a_upstream.py`
+- `tests/run_a2a_watch_artifacts.py`
+- `docs/interop/MCP_CHANGE_MANAGEMENT.md`
+- `docs/interop/MCP_UPSTREAM_TRACKING.json`
+- `.github/workflows/mcp-watch.yml`
+- `scripts/check_mcp_upstream.py`
+- `tests/run_mcp_watch_artifacts.py`
 
 3. One-command interop conformance wrappers:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/scripts/run_a2a_conformance.sh`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/scripts/run_mcp_conformance.sh`
+- `scripts/run_a2a_conformance.sh`
+- `scripts/run_mcp_conformance.sh`
 
 4. Conformance suite and CI parity updates:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/run_all_checks.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_conformance_suite.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/.github/workflows/ci.yml`
+- `conformance/run_all_checks.py`
+- `tests/run_conformance_suite.py`
+- `.github/workflows/ci.yml`
 
 ## 3) Conformance Evidence
 
 RC suite report artifact:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/reports/faxp_conformance_suite_v0.2.0-rc.3.json`
+- `conformance/reports/faxp_conformance_suite_v0.2.0-rc.3.json`
 
 Report summary:
 - `totalChecks`: `20`
@@ -70,14 +70,14 @@ A2A and MCP compatibility remain interop/certification concerns, not FAXP core p
 Verify working tree:
 
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 git status
 ```
 
 Run release gates:
 
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 .venv/bin/python tests/run_release_readiness.py
 .venv/bin/python conformance/run_all_checks.py --output conformance/reports/faxp_conformance_suite_v0.2.0-rc.3.json --log-dir /tmp/faxp-rc3-logs
 ```
@@ -85,7 +85,7 @@ cd /Users/zglitch009/projects/logistics-ai/FAXP
 Commit RC package artifacts:
 
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 git add docs/releases/RELEASE_CANDIDATE_v0.2.0-rc.3.md docs/governance/DECISION_RECORD_a2a-mcp-interop-boundary_2026-02-23.md conformance/reports/faxp_conformance_suite_v0.2.0-rc.3.json
 git commit -m "Add v0.2.0-rc.3 interop boundary decision and release package"
 git push
@@ -94,7 +94,7 @@ git push
 Tag RC:
 
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 git tag -a v0.2.0-rc.3 -m "FAXP v0.2.0-rc.3"
 git push origin v0.2.0-rc.3
 ```

--- a/docs/releases/RELEASE_NOTES_v0.2.0-alpha.1.md
+++ b/docs/releases/RELEASE_NOTES_v0.2.0-alpha.1.md
@@ -13,7 +13,7 @@ This alpha consolidates the v0.2 neutrality/security foundation while preserving
 - Neutral `VerificationResult.provider` IDs in simulation outputs.
 - Legacy compatibility preserved via `providerAlias` and legacy metadata fields.
 - v0.2 compatibility schema file added:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/faxp.v0.2.schema.json`
+  - `faxp.v0.2.schema.json`
 
 2. Signed verifier attestation enforcement
 - `ExecutionReport.VerificationResult.attestation` enforced when signed verifier mode is enabled.

--- a/docs/releases/RELEASE_NOTES_v0.2.0.md
+++ b/docs/releases/RELEASE_NOTES_v0.2.0.md
@@ -38,7 +38,7 @@ Tag: `v0.2.0`
 ## Conformance Evidence
 
 Final suite report artifact:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/reports/faxp_conformance_suite_v0.2.0.json`
+- `conformance/reports/faxp_conformance_suite_v0.2.0.json`
 
 Report summary:
 - `totalChecks`: `20`
@@ -63,7 +63,7 @@ Out of scope:
 ## Verification Commands (Release Gate)
 
 ```bash
-cd /Users/zglitch009/projects/logistics-ai/FAXP
+cd <repo-root>
 ./scripts/run_a2a_conformance.sh
 ./scripts/run_mcp_conformance.sh
 .venv/bin/python tests/run_release_readiness.py

--- a/docs/rfc/RFC-v0.3-a2a-mcp-interop-maturity.md
+++ b/docs/rfc/RFC-v0.3-a2a-mcp-interop-maturity.md
@@ -100,24 +100,24 @@ FAXP already has compatibility profiles, contracts, conformance scripts, and wat
 
 ## Implementation Evidence
 1. Interop maturity profile:
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/interop_maturity_profile.v1.json`
+   - `conformance/interop_maturity_profile.v1.json`
 2. A2A artifacts and checks:
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/interop/A2A_COMPATIBILITY_PROFILE.md`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/a2a_translator_contract.json`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/a2a_roundtrip_fixtures.json`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/.github/workflows/a2a-watch.yml`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_a2a_profile_check.py`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_a2a_roundtrip_translation.py`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_a2a_watch_artifacts.py`
+   - `docs/interop/A2A_COMPATIBILITY_PROFILE.md`
+   - `conformance/a2a_translator_contract.json`
+   - `conformance/a2a_roundtrip_fixtures.json`
+   - `.github/workflows/a2a-watch.yml`
+   - `tests/run_a2a_profile_check.py`
+   - `tests/run_a2a_roundtrip_translation.py`
+   - `tests/run_a2a_watch_artifacts.py`
 3. MCP artifacts and checks:
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/interop/MCP_COMPATIBILITY_PROFILE.md`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/mcp_tooling_contract.json`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/.github/workflows/mcp-watch.yml`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_mcp_profile_check.py`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_mcp_watch_artifacts.py`
+   - `docs/interop/MCP_COMPATIBILITY_PROFILE.md`
+   - `conformance/mcp_tooling_contract.json`
+   - `.github/workflows/mcp-watch.yml`
+   - `tests/run_mcp_profile_check.py`
+   - `tests/run_mcp_watch_artifacts.py`
 4. Certification/governance alignment:
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/governance/CERTIFICATION_PLAYBOOK.md`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_interop_maturity_profile.py`
+   - `docs/governance/CERTIFICATION_PLAYBOOK.md`
+   - `tests/run_interop_maturity_profile.py`
 
 ## Approval
 - Maintainer Approval:

--- a/docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md
+++ b/docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md
@@ -23,11 +23,11 @@ This RFC closes that gap while preserving the scope boundary: FAXP standardizes 
 ## Scope Gate (Required)
 - Scope Classification: `In-Scope`
 - Protocol-Core Impacted Files:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp_mvp_simulation.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.v0.2.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/streamlit_app.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/` (new or updated profile artifact)
+  - `faxp_mvp_simulation.py`
+  - `faxp.schema.json`
+  - `faxp.v0.2.schema.json`
+  - `streamlit_app.py`
+  - `conformance/` (new or updated profile artifact)
 - Message Types Added/Changed:
   - `NewLoad` (accessorial contract terms extension only)
   - `BidRequest` (accessorial acceptance/counter semantics extension only)
@@ -103,17 +103,17 @@ This RFC closes that gap while preserving the scope boundary: FAXP standardizes 
 
 ## Implementation Evidence
 - Runtime:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp_mvp_simulation.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/streamlit_app.py`
+  - `faxp_mvp_simulation.py`
+  - `streamlit_app.py`
 - Conformance/Profile:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/accessorial_terms_profile.v1.json`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/accessorial_type_registry.v1.json`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/detention_terms_profile.v1.json`
+  - `conformance/accessorial_terms_profile.v1.json`
+  - `conformance/accessorial_type_registry.v1.json`
+  - `conformance/detention_terms_profile.v1.json`
 - Tests:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_accessorial_terms.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_accessorial_terms_profile.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_accessorial_type_registry.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_detention_terms_profile.py`
+  - `tests/run_accessorial_terms.py`
+  - `tests/run_accessorial_terms_profile.py`
+  - `tests/run_accessorial_type_registry.py`
+  - `tests/run_detention_terms_profile.py`
 
 ## Approval
 - Maintainer Approval: Approved

--- a/docs/rfc/RFC-v0.3-adapter-certification-profile-v2.md
+++ b/docs/rfc/RFC-v0.3-adapter-certification-profile-v2.md
@@ -23,7 +23,7 @@ Current certification artifacts establish baseline conformance and governance co
 - Message Types Added/Changed:
   - None.
 - Schema Fields Added/Changed:
-  - Certification/profile schemas in `/Users/zglitch009/projects/logistics-ai/FAXP/conformance/` (planning target).
+  - Certification/profile schemas in `conformance/` (planning target).
   - Registry metadata fields for profile versioning and evidence classing (planning target).
 
 ### Required Checks
@@ -101,17 +101,17 @@ Current certification artifacts establish baseline conformance and governance co
 
 ## Implementation Evidence
 1. v2 profile artifact:
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/adapter_certification_profile.v2.json`
+   - `conformance/adapter_certification_profile.v2.json`
 2. v2 validation test:
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_adapter_certification_profile_v2.py`
+   - `tests/run_adapter_certification_profile_v2.py`
 3. Certification/governance updates:
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/governance/CERTIFICATION_PLAYBOOK.md`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/governance/GOVERNANCE_INDEX.json`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/governance/RELEASE_READINESS_CHECKLIST.md`
+   - `docs/governance/CERTIFICATION_PLAYBOOK.md`
+   - `docs/governance/GOVERNANCE_INDEX.json`
+   - `docs/governance/RELEASE_READINESS_CHECKLIST.md`
 4. Conformance/CI wiring:
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/run_all_checks.py`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_conformance_suite.py`
-   - `/Users/zglitch009/projects/logistics-ai/FIX-F/.github/workflows/ci.yml`
+   - `conformance/run_all_checks.py`
+   - `tests/run_conformance_suite.py`
+   - `.github/workflows/ci.yml`
 
 ## Approval
 - Maintainer Approval:

--- a/docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md
+++ b/docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md
@@ -18,10 +18,10 @@ Current equipment support covers common classes and core matching behavior, but 
 ## Scope Gate (Required)
 - Scope Classification: `In-Scope`
 - Protocol-Core Impacted Files:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp_mvp_simulation.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.v0.2.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/equipment_profile.v1.json`
+  - `faxp_mvp_simulation.py`
+  - `faxp.schema.json`
+  - `faxp.v0.2.schema.json`
+  - `conformance/equipment_profile.v1.json`
 - Message Types Added/Changed:
   - `NewLoad` (equipment term normalization/validation only)
   - `LoadSearch` (equipment filter normalization/validation only)
@@ -104,14 +104,14 @@ Current equipment support covers common classes and core matching behavior, but 
 
 ## Implementation Evidence
 - Runtime:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp_mvp_simulation.py`
+  - `faxp_mvp_simulation.py`
 - Conformance/Profile:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/equipment_profile.v1.json`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/equipment_type_alias_coverage.v1.json`
+  - `conformance/equipment_profile.v1.json`
+  - `conformance/equipment_type_alias_coverage.v1.json`
 - Tests:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_equipment_terms.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_equipment_profile.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_equipment_type_alias_coverage.py`
+  - `tests/run_equipment_terms.py`
+  - `tests/run_equipment_profile.py`
+  - `tests/run_equipment_type_alias_coverage.py`
 
 ## Approval
 - Maintainer Approval: Approved

--- a/docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md
+++ b/docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md
@@ -18,10 +18,10 @@ Current behavior includes the policy concepts (`HardBlock`, `SoftHold`, `GraceCa
 ## Scope Gate (Required)
 - Scope Classification: `In-Scope`
 - Protocol-Core Impacted Files:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/POLICY_PROFILES.md`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_policy_decisions.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_policy_profile_sync.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/faxp_mvp_simulation.py` (policy-decision mapping only)
+  - `docs/governance/POLICY_PROFILES.md`
+  - `tests/run_policy_decisions.py`
+  - `tests/run_policy_profile_sync.py`
+  - `faxp_mvp_simulation.py` (policy-decision mapping only)
 - Message Types Added/Changed:
   - No new message types.
   - Existing booking messages may include standardized policy decision metadata.
@@ -97,14 +97,14 @@ Current behavior includes the policy concepts (`HardBlock`, `SoftHold`, `GraceCa
 
 ## Implementation Evidence
 - Runtime:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp_mvp_simulation.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/streamlit_state_logic.py`
+  - `faxp_mvp_simulation.py`
+  - `streamlit_state_logic.py`
 - Conformance/Profile:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/verification_policy_profile.v1.json`
+  - `conformance/verification_policy_profile.v1.json`
 - Tests:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_verification_policy_profile.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_policy_decisions.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_policy_profile_sync.py`
+  - `tests/run_verification_policy_profile.py`
+  - `tests/run_policy_decisions.py`
+  - `tests/run_policy_profile_sync.py`
 
 ## Approval
 - Maintainer Approval: Approved

--- a/docs/rfc/RFC-v0.3-rate-model-extensibility.md
+++ b/docs/rfc/RFC-v0.3-rate-model-extensibility.md
@@ -18,9 +18,9 @@ Initial behavior supported `PerMile` and `Flat` only. This was too narrow for br
 ## Scope Gate (Required)
 - Scope Classification: `In-Scope`
 - Protocol-Core Impacted Files:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/faxp.v0.2.schema.json` (compatibility bridge updates for v0.3 migration)
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/faxp_mvp_simulation.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/streamlit_app.py`
+  - `faxp.v0.2.schema.json` (compatibility bridge updates for v0.3 migration)
+  - `faxp_mvp_simulation.py`
+  - `streamlit_app.py`
 - Message Types Added/Changed:
   - `NewLoad` (rate object extension only)
   - `LoadSearch` (rate filter extension only)
@@ -104,18 +104,18 @@ Initial behavior supported `PerMile` and `Flat` only. This was too narrow for br
 
 ## Implementation Evidence
 - Runtime:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp_mvp_simulation.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/streamlit_app.py`
+  - `faxp_mvp_simulation.py`
+  - `streamlit_app.py`
 - Schema:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.v0.2.schema.json`
+  - `faxp.schema.json`
+  - `faxp.v0.2.schema.json`
 - Conformance/Profile:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/rate_model_profile.v1.json`
+  - `conformance/rate_model_profile.v1.json`
 - Tests:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_rate_model_extensibility.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_rate_model_requirements.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_rate_search_requirements.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_rate_model_profile.py`
+  - `tests/run_rate_model_extensibility.py`
+  - `tests/run_rate_model_requirements.py`
+  - `tests/run_rate_search_requirements.py`
+  - `tests/run_rate_model_profile.py`
 
 ## Approval
 - Maintainer Approval: Approved

--- a/docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md
+++ b/docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md
@@ -22,11 +22,11 @@ Adding these models improves practical coverage without expanding into dispatch 
 ## Scope Gate (Required)
 - Scope Classification: `In-Scope`
 - Protocol-Core Impacted Files:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp_mvp_simulation.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.v0.2.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/rate_model_profile.v1.json` (or version bump successor)
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/streamlit_app.py`
+  - `faxp_mvp_simulation.py`
+  - `faxp.schema.json`
+  - `faxp.v0.2.schema.json`
+  - `conformance/rate_model_profile.v1.json` (or version bump successor)
+  - `streamlit_app.py`
 - Message Types Added/Changed:
   - `NewLoad` (rate object extension only)
   - `LoadSearch` (rate filter extension only)
@@ -111,17 +111,17 @@ Adding these models improves practical coverage without expanding into dispatch 
 
 ## Implementation Evidence
 - Runtime:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp_mvp_simulation.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/streamlit_app.py`
+  - `faxp_mvp_simulation.py`
+  - `streamlit_app.py`
 - Conformance/Profile:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/rate_model_profile.v1.json`
+  - `conformance/rate_model_profile.v1.json`
 - Schema:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp.v0.2.schema.json`
+  - `faxp.schema.json`
+  - `faxp.v0.2.schema.json`
 - Tests:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_rate_model_extensibility.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_rate_model_requirements.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_rate_search_requirements.py`
+  - `tests/run_rate_model_extensibility.py`
+  - `tests/run_rate_model_requirements.py`
+  - `tests/run_rate_search_requirements.py`
 
 ## Approval
 - Maintainer Approval: Approved

--- a/docs/rfc/RFC-v0.3-schema-version-negotiation.md
+++ b/docs/rfc/RFC-v0.3-schema-version-negotiation.md
@@ -18,9 +18,9 @@ As FAXP evolves, agents will run mixed versions in production. Without explicit 
 ## Scope Gate (Required)
 - Scope Classification: `In-Scope`
 - Protocol-Core Impacted Files:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/faxp.v0.2.schema.json`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/faxp_mvp_simulation.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/tests/run_schema_compatibility.py`
+  - `faxp.v0.2.schema.json`
+  - `faxp_mvp_simulation.py`
+  - `tests/run_schema_compatibility.py`
 - Message Types Added/Changed:
   - No new message types required.
   - Existing envelope metadata validation rules are clarified.
@@ -97,13 +97,13 @@ As FAXP evolves, agents will run mixed versions in production. Without explicit 
 
 ## Implementation Evidence
 - Runtime:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp_mvp_simulation.py`
+  - `faxp_mvp_simulation.py`
 - Conformance/Profile:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/protocol_compatibility_profile.v1.json`
+  - `conformance/protocol_compatibility_profile.v1.json`
 - Tests:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_protocol_version_negotiation.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_protocol_compatibility_profile.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_cross_version_fixtures.py`
+  - `tests/run_protocol_version_negotiation.py`
+  - `tests/run_protocol_compatibility_profile.py`
+  - `tests/run_cross_version_fixtures.py`
 
 ## Approval
 - Maintainer Approval: Approved

--- a/docs/rfc/RFC-v0.3-shipper-orchestration-minimal.md
+++ b/docs/rfc/RFC-v0.3-shipper-orchestration-minimal.md
@@ -18,9 +18,9 @@ FAXP already demonstrates broker-carrier and load/truck happy paths. A minimal s
 ## Scope Gate (Required)
 - Scope Classification: `In-Scope`
 - Protocol-Core Impacted Files:
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/faxp_mvp_simulation.py`
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/streamlit_app.py` (optional toggle-only update)
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/faxp.v0.2.schema.json` (only if metadata fields are added)
+  - `faxp_mvp_simulation.py`
+  - `streamlit_app.py` (optional toggle-only update)
+  - `faxp.v0.2.schema.json` (only if metadata fields are added)
 - Message Types Added/Changed:
   - No new required message types.
   - Existing booking-plane message types remain primary (`NewLoad`, `LoadSearch`, `BidRequest`, `BidResponse`, `ExecutionReport`, `AmendRequest`).
@@ -90,13 +90,13 @@ FAXP already demonstrates broker-carrier and load/truck happy paths. A minimal s
 
 ## Implementation Evidence
 - Runtime:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/faxp_mvp_simulation.py` (`--shipper-flow`)
+  - `faxp_mvp_simulation.py` (`--shipper-flow`)
 - Conformance/Profile:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/conformance/shipper_orchestration_profile.v1.json`
+  - `conformance/shipper_orchestration_profile.v1.json`
 - Tests:
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_shipper_orchestration_minimal.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_shipper_orchestration_profile.py`
-  - `/Users/zglitch009/projects/logistics-ai/FIX-F/tests/run_role_capability_policy.py`
+  - `tests/run_shipper_orchestration_minimal.py`
+  - `tests/run_shipper_orchestration_profile.py`
+  - `tests/run_role_capability_policy.py`
 
 ## Approval
 - Maintainer Approval: Approved

--- a/docs/roadmap/FAXP_DEFERRED_ITEMS.md
+++ b/docs/roadmap/FAXP_DEFERRED_ITEMS.md
@@ -12,8 +12,8 @@ This note tracks governance/tooling items intentionally deferred while v0.1.x st
 
 ## Current Scope (Implemented Now)
 
-1. Canonical protocol schema at `/Users/zglitch009/projects/logistics-ai/FAXP/faxp.schema.json`.
-2. Runtime message validation inside `/Users/zglitch009/projects/logistics-ai/FAXP/faxp_mvp_simulation.py`.
+1. Canonical protocol schema at `faxp.schema.json`.
+2. Runtime message validation inside `faxp_mvp_simulation.py`.
 3. Explicit protocol metadata in message envelope: `Protocol` + `ProtocolVersion`.
 
 ## Revisit Trigger

--- a/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md
+++ b/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md
@@ -16,7 +16,7 @@ Purpose: Central place to capture commercial model requirements before implement
 
 1. `PerPallet` rate model
 - Target: `v0.3.0`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- RFC: `docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 - Acceptance:
   - Negotiation supports `PerPallet`.
   - Validation enforces pallet-count terms.
@@ -24,7 +24,7 @@ Purpose: Central place to capture commercial model requirements before implement
 
 2. `CWT` (Hundredweight) rate model
 - Target: `v0.3.0`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- RFC: `docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 - Acceptance:
   - Negotiation supports weight-unit terms.
   - Validation enforces weight basis.
@@ -32,7 +32,7 @@ Purpose: Central place to capture commercial model requirements before implement
 
 3. LineHaul + Fuel Surcharge componentized rates
 - Target: `v0.3.0`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- RFC: `docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 - Acceptance:
   - `RateComponents` supports at least `LineHaul` and `FuelSurcharge`.
   - Total agreed-rate can be derived deterministically.
@@ -41,14 +41,14 @@ Purpose: Central place to capture commercial model requirements before implement
 
 1. Agreed miles field for `PerMile`
 - Target: `v0.3.0`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- RFC: `docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 - Acceptance:
   - `AgreedMiles` captured in commercial terms.
   - `MilesSource` and timestamp/version are auditable.
 
 2. Miles dispute/negotiation flow
 - Target: `v0.3.0`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- RFC: `docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 - Acceptance:
   - Counter/reason code supports mileage disputes.
   - Final agreed miles immutable in execution record.
@@ -57,7 +57,7 @@ Purpose: Central place to capture commercial model requirements before implement
 
 1. Multi-pick / multi-drop stop model
 - Target: `v0.3.1`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
+- RFC: `docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
 - Acceptance:
   - Ordered stop list with pickup/drop semantics.
   - Backward-compatible single-stop default.
@@ -65,7 +65,7 @@ Purpose: Central place to capture commercial model requirements before implement
 
 2. Service requirements (reefer temp bands, tarping, handling constraints)
 - Target: `v0.3.1`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
+- RFC: `docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
 - Acceptance:
   - Booking-time `SpecialInstructions` terms with explicit accept/counter semantics.
   - Carrier can return exceptions through `SpecialInstructionsAcceptance`.
@@ -73,7 +73,7 @@ Purpose: Central place to capture commercial model requirements before implement
 
 3. Required delivery date / service commitment windows
 - Target: `v0.3.1`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
+- RFC: `docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
 - Acceptance:
   - Pickup date range remains required and validated (`PickupEarliest`/`PickupLatest`).
   - Delivery date range and pickup/delivery time windows are structured and validated when provided.
@@ -81,7 +81,7 @@ Purpose: Central place to capture commercial model requirements before implement
 
 4. Equipment taxonomy expansion (specialty trailers + dimensional constraints)
 - Target: `v0.3.x`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md`
+- RFC: `docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md`
 - Acceptance:
   - Trailer type vocabulary includes `Hopper`, `StepDeck`, and others.
   - Trailer size/length is normalized and validated by equipment type.
@@ -89,7 +89,7 @@ Purpose: Central place to capture commercial model requirements before implement
 
 5. Driver configuration requirements (single vs team) for expedited freight
 - Target: `v0.3.1`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
+- RFC: `docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
 - Acceptance:
   - Load can declare required driver configuration.
   - Carrier bid can declare provided configuration.
@@ -97,7 +97,7 @@ Purpose: Central place to capture commercial model requirements before implement
 
 6. Neutral external load reference metadata
 - Target: `v0.3.1`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
+- RFC: `docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
 - Acceptance:
   - Load carries `LoadReferenceNumbers` distinct from protocol `LoadID`.
   - Supports neutral `PrimaryReferenceNumber` / `SecondaryReferenceNumber` and typed additional references.
@@ -107,13 +107,13 @@ Purpose: Central place to capture commercial model requirements before implement
 
 1. Additional rate structures (hourly, lane-minimums, tiered pricing)
 - Target: `v0.3.x`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md`
+- RFC: `docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md`
 - Acceptance:
   - Added only via RFC with compatibility plan.
 
 2. Advanced accessorial lifecycle scenarios
 - Target: `v0.3.x`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md`
+- RFC: `docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md`
 - Acceptance:
   - Clear pre-booking vs post-booking claim-state boundaries.
   - Explicit booking-time payer/payee responsibility semantics.
@@ -123,7 +123,7 @@ Purpose: Central place to capture commercial model requirements before implement
 
 1. Booking-plane accessorial/addendum contract baseline
 - Target: `v0.3.0`
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- RFC: `docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 - Acceptance:
   - Commercial terms are structured for booking (`PricingMode`, `PayerParty`, `PayeeParty`, optional `CapAmount`).
   - Settlement/payment execution remains explicitly out of scope in governance docs.

--- a/docs/roadmap/V0_3_0_GOVERNANCE_CHECKPOINT.md
+++ b/docs/roadmap/V0_3_0_GOVERNANCE_CHECKPOINT.md
@@ -42,9 +42,9 @@ This checkpoint converts the merged v0.3 RFC drafts into an execution order with
 ## Supporting Planning Artifacts
 
 1. Commercial model backlog:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md`
+- `docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md`
 2. Scenario catalog:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md`
+- `docs/roadmap/V0_3_0_SCENARIO_CATALOG.md`
 
 ## Scope Guardrails (Reconfirmed)
 

--- a/docs/roadmap/V0_3_0_RFC_BACKLOG.md
+++ b/docs/roadmap/V0_3_0_RFC_BACKLOG.md
@@ -6,15 +6,15 @@ Scope policy: Booking-plane and certification governance only.
 
 ## Process
 
-1. Create RFC from `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC_TEMPLATE.md`.
+1. Create RFC from `docs/rfc/RFC_TEMPLATE.md`.
 2. Classify scope gate in each RFC (`In-Scope` or `Scope Expansion`).
 3. Require security and conformance impact section.
 4. Require migration/backward-compatibility note for schema/runtime changes.
 5. Only after governance acceptance: move item into implementation checklist.
 6. Map each RFC item to at least one scenario in:
-   - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md`
+   - `docs/roadmap/V0_3_0_SCENARIO_CATALOG.md`
 7. Track open commercial requirements in:
-   - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md`
+   - `docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md`
 
 ## Priority Backlog
 
@@ -24,7 +24,7 @@ Scope policy: Booking-plane and certification governance only.
 - Status: `Accepted (Implemented)`
 - Target: `v0.3.0`
 - Notes: Implemented with active model set (`PerMile`, `Flat`, `PerPallet`, `CWT`, `PerHour`, `LaneMinimum`) and fail-closed validation/profile gates.
-- Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- Draft file: `docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 
 2. `RFC-v0.3-shipper-orchestration-minimal`
 - Goal: Wire existing ShipperAgent stub into an optional shipper -> broker -> carrier booking path.
@@ -32,7 +32,7 @@ Scope policy: Booking-plane and certification governance only.
 - Status: `Accepted (Implemented)`
 - Target: `v0.3.x`
 - Notes: Implemented as optional shipper entry flow with role-capability policy and conformance gates; broker-carrier path remains unchanged.
-- Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-shipper-orchestration-minimal.md`
+- Draft file: `docs/rfc/RFC-v0.3-shipper-orchestration-minimal.md`
 
 3. `RFC-v0.3-schema-version-negotiation`
 - Goal: Formalize version negotiation and compatibility behavior for mixed v0.2/v0.3 agents.
@@ -40,7 +40,7 @@ Scope policy: Booking-plane and certification governance only.
 - Status: `Accepted (Implemented)`
 - Target: `v0.3.0`
 - Notes: Implemented with protocol compatibility profile, cross-version fixtures, and fail-closed negotiation checks.
-- Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-schema-version-negotiation.md`
+- Draft file: `docs/rfc/RFC-v0.3-schema-version-negotiation.md`
 
 4. `RFC-v0.3-adapter-certification-profile-v2`
 - Goal: Advance certification profile and registry policy requirements for builder-hosted adapters.
@@ -48,7 +48,7 @@ Scope policy: Booking-plane and certification governance only.
 - Status: `Accepted (Implemented)`
 - Target: `v0.3.x`
 - Notes: Implemented with explicit evidence classes, registry metadata requirements, dual v1/v2 transition support, and release-gated conformance/CI checks.
-- Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-adapter-certification-profile-v2.md`
+- Draft file: `docs/rfc/RFC-v0.3-adapter-certification-profile-v2.md`
 
 5. `RFC-v0.3-provisional-booking-policy-contract`
 - Goal: Standardize policy semantics for `HardBlock`, `SoftHold`, and `GraceCache` outcomes.
@@ -56,7 +56,7 @@ Scope policy: Booking-plane and certification governance only.
 - Status: `Accepted (Implemented)`
 - Target: `v0.3.0`
 - Notes: Implemented with normalized decision metadata, risk-tier matrix semantics, and release-gated conformance checks.
-- Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md`
+- Draft file: `docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md`
 
 6. `RFC-v0.3-a2a-mcp-interop-maturity`
 - Goal: Define maturity criteria for translator/tool evidence interoperability across A2A and MCP tracks.
@@ -64,7 +64,7 @@ Scope policy: Booking-plane and certification governance only.
 - Status: `Accepted (Implemented)`
 - Target: `v0.3.x`
 - Notes: Implemented as an optional interop maturity profile with evidence-backed A2A/MCP track criteria and no mandatory A2A/MCP runtime dependency in FAXP core.
-- Draft file: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-a2a-mcp-interop-maturity.md`
+- Draft file: `docs/rfc/RFC-v0.3-a2a-mcp-interop-maturity.md`
 
 7. `RFC-v0.3-equipment-taxonomy-expansion`
 - Goal: Standardize specialty trailer taxonomy and dimensional compatibility semantics for booking-plane matching.
@@ -72,7 +72,7 @@ Scope policy: Booking-plane and certification governance only.
 - Status: `Accepted (Implemented)`
 - Target: `v0.3.x`
 - Notes: Implemented with canonical class/subclass/tag normalization, alias coverage, and trailer length range compatibility semantics.
-- Draft file: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md`
+- Draft file: `docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md`
 
 8. `RFC-v0.3-rate-model-hourly-lane-minimum`
 - Goal: Add booking-plane `PerHour` and `LaneMinimum` rate models with deterministic validation and execution normalization.
@@ -80,7 +80,7 @@ Scope policy: Booking-plane and certification governance only.
 - Status: `Accepted (Implemented)`
 - Target: `v0.3.x`
 - Notes: Implemented with booking-plane-only scope and fail-closed model validation semantics.
-- Draft file: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md`
+- Draft file: `docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md`
 
 9. `RFC-v0.3-accessorial-lifecycle-booking-plane`
 - Goal: Standardize accessorial booking-time terms, payer/payee responsibility, and post-booking claim states without entering settlement workflows.
@@ -88,7 +88,7 @@ Scope policy: Booking-plane and certification governance only.
 - Status: `Accepted (Implemented)`
 - Target: `v0.3.x`
 - Notes: Implemented as booking-plane-only contract semantics with external evidence references and explicit settlement/document-custody scope boundaries.
-- Draft file: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md`
+- Draft file: `docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md`
 
 ## Deferred / Explicitly Out-of-Scope for v0.3.0 RFC Batch
 
@@ -106,7 +106,7 @@ These remain scope expansions and require separate governance track beyond curre
 - Status: `Draft` (Deferred to v0.3.x)
 - Target: `v0.3.x`
 - Notes: Optional metadata only; no FAXP-hosted oracle services and no mandatory vendor coupling.
-- Draft file: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-rate-oracle-extension.md`
+- Draft file: `docs/rfc/RFC-v0.3-rate-oracle-extension.md`
 
 11. `RFC-v0.3-operational-handoff-metadata`
 - Goal: Define optional neutral post-booking handoff metadata so systems can route completed bookings into the correct downstream ops workflow without moving dispatch into protocol core.
@@ -114,4 +114,4 @@ These remain scope expansions and require separate governance track beyond curre
 - Status: `Draft` (Deferred to v0.3.x)
 - Target: `v0.3.x`
 - Notes: Routing intent only; no dispatch packet content, appointment lifecycle, document custody, or settlement workflow state.
-- Draft file: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-operational-handoff-metadata.md`
+- Draft file: `docs/rfc/RFC-v0.3-operational-handoff-metadata.md`

--- a/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md
+++ b/docs/roadmap/V0_3_0_SCENARIO_CATALOG.md
@@ -14,7 +14,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S1: PerMile with Agreed Miles
 
 - Description: Broker posts `PerMile` load with proposed miles; carrier accepts or counters miles.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- RFC: `docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 - Target: `v0.3.0`
 - Expected outcome:
   - Final contract contains agreed miles and agreed rate.
@@ -23,7 +23,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S2: PerPallet Negotiation
 
 - Description: Broker posts palletized freight with `PerPallet` pricing.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- RFC: `docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 - Target: `v0.3.0`
 - Expected outcome:
   - Pallet terms validated.
@@ -32,7 +32,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S3: CWT Negotiation
 
 - Description: Load priced per hundredweight (`CWT`).
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- RFC: `docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 - Target: `v0.3.0`
 - Expected outcome:
   - Weight basis and units validated.
@@ -41,7 +41,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S4: LineHaul + Fuel Surcharge Split
 
 - Description: Rate is negotiated as two components: linehaul plus FSC.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-rate-model-extensibility.md`
+- RFC: `docs/rfc/RFC-v0.3-rate-model-extensibility.md`
 - Target: `v0.3.0`
 - Expected outcome:
   - Component values preserved.
@@ -50,7 +50,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S5: Multi-Pick / Multi-Drop
 
 - Description: Load includes multiple pickups and drops.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
+- RFC: `docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
 - Target: `v0.3.1`
 - Expected outcome:
   - Ordered stop list and constraints.
@@ -60,7 +60,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S6: Reefer Temperature Requirement
 
 - Description: Reefer load requires specific temperature range and monitoring instructions.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
+- RFC: `docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
 - Target: `v0.3.1`
 - Expected outcome:
   - Requirement can be represented in `SpecialInstructions`.
@@ -69,7 +69,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S7: Flatbed Tarping Requirement
 
 - Description: Flatbed load requires tarping and securement notes.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
+- RFC: `docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
 - Target: `v0.3.1`
 - Expected outcome:
   - Requirement can be represented in `SpecialInstructions`.
@@ -78,7 +78,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S8: Verification Degraded Path with Provisional Hold
 
 - Description: Verification provider outage triggers `SoftHold` or `GraceCache` path.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md`
+- RFC: `docs/rfc/RFC-v0.3-provisional-booking-policy-contract.md`
 - Target: `v0.3.0`
 - Expected outcome:
   - Deterministic policy decision.
@@ -87,7 +87,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S9: Required Delivery Date Commitment
 
 - Description: Shipper/broker requires delivery by specific date/time window.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
+- RFC: `docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
 - Target: `v0.3.1`
 - Expected outcome:
   - Delivery commitment fields are structured and validated.
@@ -97,7 +97,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S10: Trailer Size Match (`53'` vs `48'` Reefer)
 
 - Description: Load requires specific reefer trailer size.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md`
+- RFC: `docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md`
 - Target: `v0.3.x`
 - Expected outcome:
   - Equipment matching distinguishes size-sensitive requirements.
@@ -106,7 +106,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S11: Specialty Trailer Match (Hopper / StepDeck)
 
 - Description: Load requires non-standard trailer class.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md`
+- RFC: `docs/rfc/RFC-v0.3-equipment-taxonomy-expansion.md`
 - Target: `v0.3.x`
 - Expected outcome:
   - Specialty equipment taxonomy is structured and validated.
@@ -115,7 +115,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S12: Expedited Team Driver Requirement
 
 - Description: Expedited shipment requires team drivers.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
+- RFC: `docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
 - Target: `v0.3.1`
 - Expected outcome:
   - Driver configuration requirement is explicit in load terms.
@@ -125,7 +125,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S13: External Load Reference Correlation
 
 - Description: Broker and shipper need neutral cross-system reference numbers distinct from protocol `LoadID`.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
+- RFC: `docs/governance/BOOKING_PLANE_COMMERCIAL_TERMS.md`
 - Target: `v0.3.1`
 - Expected outcome:
   - `NewLoad` can include `LoadReferenceNumbers` with neutral primary/secondary reference numbers.
@@ -135,7 +135,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S14: PerHour Negotiation for Dwell/Local Service
 
 - Description: Broker and carrier negotiate a `PerHour` booking-plane rate with explicit hours basis for a local or delay-sensitive load.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md`
+- RFC: `docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md`
 - Target: `v0.3.x`
 - Expected outcome:
   - `RateModel=PerHour` validates model-specific fields and unit basis deterministically.
@@ -145,7 +145,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S15: LaneMinimum Commercial Floor Contract
 
 - Description: Carrier and broker negotiate a lane floor where `LaneMinimum` applies when computed components fall below a minimum total.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md`
+- RFC: `docs/rfc/RFC-v0.3-rate-model-hourly-lane-minimum.md`
 - Target: `v0.3.x`
 - Expected outcome:
   - `RateModel=LaneMinimum` validates required minimum semantics and fails closed when incomplete.
@@ -155,7 +155,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S16: Detention Terms Agreed at Booking
 
 - Description: Broker and carrier agree detention commercial terms at booking time, including rate basis and responsibility.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md`
+- RFC: `docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md`
 - Target: `v0.3.x`
 - Expected outcome:
   - Accessorial terms are explicit (type, pricing mode, payer/payee, pre-approval/evidence requirements).
@@ -165,7 +165,7 @@ Purpose: Concrete scenarios used to drive RFC decisions and acceptance tests.
 ### S17: Post-Booking Accessorial Claim with External Evidence Reference
 
 - Description: Carrier proposes a post-booking accessorial claim and references external proof metadata (not raw documents) for review.
-- RFC: `/Users/zglitch009/projects/logistics-ai/FIX-F/docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md`
+- RFC: `docs/rfc/RFC-v0.3-accessorial-lifecycle-booking-plane.md`
 - Target: `v0.3.x`
 - Expected outcome:
   - Claim state follows booking-plane contract (`Proposed -> Approved|Rejected`).

--- a/docs/roadmap/V2_IMPLEMENTATION_CHECKLIST.md
+++ b/docs/roadmap/V2_IMPLEMENTATION_CHECKLIST.md
@@ -1,7 +1,7 @@
 # FAXP v0.2 Implementation Checklist (From RFC Verification Neutrality)
 
 Status: Alpha Candidate  
-Source RFC: `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.2-verification-neutrality.md`  
+Source RFC: `docs/rfc/RFC-v0.2-verification-neutrality.md`  
 Updated: 2026-02-21 (alpha evidence closure)
 
 ## Phase 0: Branch + Baseline
@@ -16,8 +16,8 @@ Updated: 2026-02-21 (alpha evidence closure)
 ## Phase 1: Schema Updates (Provider-Agnostic Verification)
 
 Target files:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/faxp.schema.json` (v0.1.1 baseline)
-- `/Users/zglitch009/projects/logistics-ai/FAXP/faxp.v0.2.schema.json` (compatibility track)
+- `faxp.schema.json` (v0.1.1 baseline)
+- `faxp.v0.2.schema.json` (compatibility track)
 
 - [x] Extend `ExecutionReport.VerificationResult` to neutral fields (in v0.2 schema):
   - [x] `status`
@@ -42,7 +42,7 @@ Acceptance:
 
 ## Phase 2: Simulation/Validator Changes
 
-Target file: `/Users/zglitch009/projects/logistics-ai/FAXP/faxp_mvp_simulation.py`
+Target file: `faxp_mvp_simulation.py`
 
 - [x] Update validation logic for `ExecutionReport.VerificationResult` neutral object.
 - [x] Add verifier attestation validation hook:
@@ -61,8 +61,8 @@ Acceptance:
 ## Phase 3: Capability Negotiation (Optional Metadata in v0.2)
 
 Targets:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/faxp_mvp_simulation.py`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/streamlit_app.py`
+- `faxp_mvp_simulation.py`
+- `streamlit_app.py`
 
 - [x] Add optional `VerificationCapabilities` structure (agent-level metadata).
 - [x] Add matching logic stub:
@@ -75,7 +75,7 @@ Acceptance:
 
 ## Phase 4: Streamlit Cloud Alignment
 
-Target file: `/Users/zglitch009/projects/logistics-ai/FAXP/streamlit_app.py`
+Target file: `streamlit_app.py`
 
 - [x] Add cloud-safe mode switch in UI/config:
   - [x] hide/disable non-cloud-safe local verifier paths.
@@ -89,9 +89,9 @@ Acceptance:
 ## Phase 5: Tests and Conformance
 
 Targets:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/faxp_mvp_simulation.py` (self-test paths)
+- `faxp_mvp_simulation.py` (self-test paths)
 - New test notes/doc file (optional):
-  - `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/TEST_MATRIX_v0.2.md`
+  - `docs/roadmap/TEST_MATRIX_v0.2.md`
 
 - [x] Add neutral-verification happy-path test vectors:
   - [x] mock provider A
@@ -112,9 +112,9 @@ Acceptance:
 ## Phase 6: Docs + Governance
 
 Targets:
-- `/Users/zglitch009/projects/logistics-ai/FAXP/README.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/roadmap/FAXP_DEFERRED_ITEMS.md`
-- `/Users/zglitch009/projects/logistics-ai/FAXP/docs/rfc/RFC-v0.2-verification-neutrality.md`
+- `README.md`
+- `docs/roadmap/FAXP_DEFERRED_ITEMS.md`
+- `docs/rfc/RFC-v0.2-verification-neutrality.md`
 
 - [x] Add protocol-neutral verification section to README.
 - [x] Document adapter pattern boundaries (core protocol vs provider adapters).


### PR DESCRIPTION
## Summary
- removes machine-specific absolute repo paths from active docs and conformance guidance
- normalizes references to repo-relative paths or `cd <repo-root>` where appropriate
- keeps historical generated reports untouched

## Scope
- documentation only
- no runtime, schema, or policy behavior changes

## Validation
- `./.venv/bin/python tests/run_governance_index.py`
- `./.venv/bin/python tests/run_release_readiness.py`
