### PR TITLE
Add Phase 2 implementation roadmap

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -36,6 +36,7 @@ This index keeps governance, roadmap, and release artifacts discoverable while k
 - `docs/interop/MCP_UPSTREAM_TRACKING.json`
 
 ## Roadmap
+- `docs/roadmap/PHASE_2_IMPLEMENTATION_ROADMAP.md`
 - `docs/roadmap/V2_IMPLEMENTATION_CHECKLIST.md`
 - `docs/roadmap/TEST_MATRIX_v0.2.md`
 - `docs/roadmap/FAXP_DEFERRED_ITEMS.md`

--- a/docs/roadmap/PHASE_2_IMPLEMENTATION_ROADMAP.md
+++ b/docs/roadmap/PHASE_2_IMPLEMENTATION_ROADMAP.md
@@ -1,0 +1,203 @@
+# FAXP Phase 2 Implementation Roadmap
+
+Status: Planned  
+Scope Class: Booking-plane implementation maturity  
+Updated: 2026-03-01
+
+## Phase 2 Goal
+
+Turn FAXP from a well-scoped booking protocol into a practical implementation standard that outside builders can integrate without expanding FAXP into dispatch, tracking, document custody, or settlement.
+
+## Scope Boundary
+
+Phase 2 remains within FAXP's current boundary:
+
+In scope:
+- booking-plane handoff and implementation maturity
+- builder integration guidance
+- optional extension planning and implementation where additive
+- certification and conformance hardening
+- scenario and interoperability coverage expansion
+
+Out of scope:
+- dispatch execution workflows
+- live tracking and telematics lifecycle
+- POD/BOL custody and document adjudication
+- invoicing, remittance, payment rails, and settlement
+- FAXP-hosted verifier or operational infrastructure
+
+## Priority Order
+
+1. Operational Handoff Metadata
+2. Counterparty Identity and Booking Reference Hardening
+3. Builder Integration Profiles
+4. Rate Oracle Extension
+5. Certification and Contributor Onboarding
+6. Scenario Expansion
+
+## 1) Operational Handoff Metadata
+
+Objective:
+Define how a valid `ExecutionReport` can be handed into downstream TMS, portal, ops-agent, or human workflow without moving dispatch into FAXP core.
+
+Primary references:
+- `docs/rfc/RFC-v0.3-operational-handoff-metadata.md`
+- `docs/governance/SCOPE_GUARDRAILS.md`
+- `docs/roadmap/V0_3_0_RFC_BACKLOG.md`
+
+Target deliverables:
+- accepted RFC and implementation checklist
+- neutral handoff metadata profile
+- explicit distinction between required booking identity and optional ops-routing metadata
+- conformance tests proving routing-only semantics
+- optional demo visibility if it helps explain downstream handoff
+
+Guardrails:
+- no dispatch packet content
+- no appointment lifecycle model
+- no dispatch state machine
+- no settlement or document-custody behavior
+
+Success criteria:
+- booking remains valid without dispatch content
+- required booking identity is explicit and testable
+- optional handoff metadata is neutral, additive, and routing-only
+- builders can route post-booking workflow consistently without custom one-off conventions
+
+## 2) Counterparty Identity and Booking Reference Hardening
+
+Objective:
+Strengthen the minimum identity and booking-reference contract so a booking is operationally meaningful even before downstream dispatch workflow begins.
+
+Target deliverables:
+- explicit booking identity profile
+- clearer guidance for `AgentID`, counterparty identity, and booking references
+- neutral booking reference requirements for external system correlation
+- tests for minimum viable booking identity on confirmed bookings
+
+Guardrails:
+- no global participant registry
+- no universal commercial trust score
+- no FAXP-owned business reputation system
+
+Success criteria:
+- a valid booking always identifies the counterparty and booking references
+- identity requirements are separated cleanly from optional operational routing metadata
+- downstream systems can correlate bookings without requiring custom local conventions
+
+## 3) Builder Integration Profiles
+
+Objective:
+Make it easier for TMSs, load boards, portals, and agent builders to implement FAXP in a repeatable, certifiable way.
+
+Target deliverables:
+- builder implementation guides for booking-plane integration
+- clearer vendor-direct verifier guidance
+- clearer implementer-hosted adapter guidance
+- implementation claim matrix for supported profiles
+- improved handoff documentation for external builders
+
+Primary references:
+- `docs/adapters/ADAPTER_IMPLEMENTER_HANDOFF.md`
+- `docs/governance/CERTIFICATION_PLAYBOOK.md`
+- `docs/governance/VERIFICATION_RESPONSIBILITY_MODEL.md`
+
+Guardrails:
+- no FAXP-hosted adapter service
+- no mandated verifier vendor
+- no protocol-core dependency on a builder-specific deployment pattern
+
+Success criteria:
+- an outside builder can identify the minimum artifacts, tests, and profiles needed for conformance
+- verifier integration patterns stay provider-neutral
+- certification expectations are concrete and reproducible
+
+## 4) Rate Oracle Extension
+
+Objective:
+Allow optional benchmark/reference rate evidence without coupling FAXP to a specific vendor or requiring an oracle in core.
+
+Primary references:
+- `docs/rfc/RFC-v0.3-rate-oracle-extension.md`
+- `docs/roadmap/V0_3_0_RFC_BACKLOG.md`
+
+Target deliverables:
+- finalized optional extension shape for benchmark/reference rate evidence
+- attribution and freshness expectations
+- conformance profile for optional use
+- explicit guidance that reference data is additive and not booking-core required
+
+Guardrails:
+- no oracle dependency in core
+- no vendor lock-in
+- no FAXP-hosted market data service
+
+Success criteria:
+- builders can attach optional rate reference evidence in a normalized way
+- the protocol remains valid without any oracle fields present
+- benchmark/reference usage is auditable and provider-neutral
+
+## 5) Certification and Contributor Onboarding
+
+Objective:
+Turn the repo into something outside builders and contributors can navigate productively after the public launch.
+
+Target deliverables:
+- clearer starter implementation issues
+- certification submission examples and review expectations
+- contributor-facing docs polish where needed
+- a more explicit "start here" path for implementers
+- early PR review conventions for public contributors
+
+Guardrails:
+- maintain PR-based merge control
+- avoid scope drift through issue triage
+- keep certification evidence-based rather than vendor-relationship-based
+
+Success criteria:
+- new contributors can identify where to start
+- builders can find certification expectations without reverse-engineering the repo
+- public issues and PRs stay aligned to current scope boundaries
+
+## 6) Scenario Expansion
+
+Objective:
+Expand booking-plane realism through more scenario coverage without drifting into operations execution.
+
+Primary references:
+- `docs/roadmap/V0_3_0_SCENARIO_CATALOG.md`
+- `docs/roadmap/V0_3_0_COMMERCIAL_MODEL_BACKLOG.md`
+
+Target deliverables:
+- more real-world booking scenarios
+- more commercial edge-case fixtures
+- richer examples across shipper, broker, and carrier roles
+- expanded interop and conformance test vectors
+
+Guardrails:
+- keep all new scenarios within booking-plane semantics
+- use external references or notes for downstream operational evidence rather than embedding dispatch or settlement logic
+
+Success criteria:
+- broader real-world commercial coverage
+- fewer ambiguous semantics for implementers
+- stronger regression confidence as adoption grows
+
+## What Phase 2 Is Not
+
+Phase 2 does not expand FAXP into:
+- dispatch execution
+- telematics/tracking lifecycle
+- POD/BOL custody
+- invoice/payment/remittance/factoring workflows
+- FAXP-hosted verification or operational services
+
+## Exit Criteria
+
+Phase 2 is complete when:
+1. operational handoff metadata has a clear RFC-backed path and implementation guidance
+2. booking identity and reference requirements are explicit and testable
+3. builder implementation guidance is materially easier to follow
+4. optional extension paths like rate oracles are defined without compromising neutrality
+5. certification and contributor workflows are ready for sustained external participation
+6. scenario coverage is strong enough to support implementation feedback without expanding protocol scope


### PR DESCRIPTION
## Summary
- adds a dedicated Phase 2 implementation roadmap focused on booking-plane implementation maturity
- defines priority order for handoff metadata, identity hardening, builder integration profiles, rate-oracle extension work, certification onboarding, and scenario expansion
- adds the new roadmap document to the docs index for contributor visibility

## Scope
- documentation only
- no runtime, schema, or policy behavior changes

## Validation
- `./.venv/bin/python tests/run_governance_index.py`
