### PR TITLE
docs: codify public comment hygiene and enforce via guardrails

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,11 @@ Public artifact hygiene rules:
 3. Use neutral identifiers and synthetic examples in public-facing artifacts.
 4. Use one branch per PR; do not reuse merged branch names.
 
+Public collaboration hygiene rules:
+1. Never post local absolute filesystem paths in public GitHub issues, PR comments, or discussions.
+2. Never post partner-specific names/identifiers in public GitHub issues, PR comments, or discussions without explicit permission.
+3. Never post tokens, credentials, bearer strings, or secret-like material in public GitHub issues, PR comments, or discussions.
+
 ## Security and Secrets
 
 - Never commit private keys, tokens, or local secret bundles.

--- a/tests/run_open_source_guardrails.py
+++ b/tests/run_open_source_guardrails.py
@@ -235,6 +235,21 @@ def main() -> int:
         "tests/run_public_redaction_guardrails.py" in contributing,
         "CONTRIBUTING.md must include public redaction guardrails check.",
     )
+    _assert(
+        "Never post local absolute filesystem paths in public GitHub issues, PR comments, or discussions."
+        in contributing,
+        "CONTRIBUTING.md must include explicit no-local-paths rule for public collaboration.",
+    )
+    _assert(
+        "Never post partner-specific names/identifiers in public GitHub issues, PR comments, or discussions"
+        in contributing,
+        "CONTRIBUTING.md must include explicit partner-identifier hygiene rule for public collaboration.",
+    )
+    _assert(
+        "Never post tokens, credentials, bearer strings, or secret-like material in public GitHub issues, PR comments, or discussions."
+        in contributing,
+        "CONTRIBUTING.md must include explicit no-secrets rule for public collaboration.",
+    )
 
     readme = _read(PROJECT_ROOT / "README.md")
     _assert("CONTRIBUTING.md" in readme, "README.md must reference CONTRIBUTING.md.")


### PR DESCRIPTION
## Summary
- add explicit public collaboration hygiene rules to `CONTRIBUTING.md`:
  - no local absolute filesystem paths in public GitHub issues/PR comments/discussions
  - no partner-specific identifiers in public GitHub discussions without explicit permission
  - no tokens/credentials/bearer/secret-like material in public GitHub discussions
- extend `tests/run_open_source_guardrails.py` to enforce these rules are present

## Why
- turns maintainer practice into a durable, test-enforced policy
- directly prevents accidental public disclosure of local paths, partner identifiers, and secret-like material
- aligns contributor guidance with existing public-redaction/security controls

## Validation
- Open-source guardrails checks passed
- Public redaction guardrails check passed
- Release readiness checks passed
