### PR TITLE
docs/tests: harden Workstream F independent implementer evidence gates

### DIFF
--- a/docs/builders/ADOPTION_EXECUTION_RUNBOOK.md
+++ b/docs/builders/ADOPTION_EXECUTION_RUNBOOK.md
@@ -47,6 +47,7 @@ Default packet to share:
 4. Capture feedback in issues before proposing protocol changes.
 5. Keep partner-specific implementation details in private channels.
 6. Before beta-promotion discussion, run the second implementer checklist and capture anonymized evidence.
+7. Do not mark second implementer criterion done from synthetic-only or mock-only demos.
 
 ## Scope Guardrail Language (Use Verbatim)
 

--- a/docs/builders/ANONYMIZED_INTEGRATION_OUTCOME_TEMPLATE.md
+++ b/docs/builders/ANONYMIZED_INTEGRATION_OUTCOME_TEMPLATE.md
@@ -20,6 +20,20 @@ vendor-neutral, and non-attributable to any partner implementation.
 - Protocol (FAXP): booking-plane message contract and envelope/body validation.
 - Adapter (implementation bridge): source API auth/session handling, source-specific payload extraction, deterministic update mechanics, and field mapping.
 
+## Independent Implementer Qualification
+
+Use this template only when the run is a real independent implementer evaluation.
+
+Required:
+1. Real sandbox API execution for a second implementer/runtime.
+2. Independent credentials/runtime boundary from the first implementer demo.
+3. Private raw evidence exists and public output is anonymized.
+
+Does not qualify:
+1. Synthetic-only payload walkthroughs.
+2. Mock-only tests with no real sandbox API interaction.
+3. Re-labeling prior implementer data as a second demo.
+
 ## What Was Validated
 1. Source-system auth/login works.
 2. Create/load retrieval flow works.

--- a/docs/builders/SECOND_IMPLEMENTER_DEMO_CHECKLIST.md
+++ b/docs/builders/SECOND_IMPLEMENTER_DEMO_CHECKLIST.md
@@ -11,6 +11,20 @@ Maturity status:
 
 Confirm that FAXP behavior is repeatable across at least two independent implementations without partner-specific dependencies.
 
+## Qualification Rule (No Pretend Demos)
+
+This checklist is only for a real second independent implementer run.
+
+Qualifies:
+1. Real sandbox API access for a separate implementer/runtime.
+2. Real create/read/update traffic captured privately, then anonymized for public artifacts.
+3. Deterministic update behavior proven with real IDs from current source state.
+
+Does not qualify:
+1. Synthetic-only payloads or mocked API responses.
+2. Re-labeling the same implementer flow as a "second" implementer.
+3. Internal-only replay of the reference runtime without an independent integration target.
+
 ## Scope Guardrails
 
 Keep demo scope inside booking-plane interoperability:
@@ -40,16 +54,17 @@ Do not include:
 
 ## Execution Checklist
 
-1. Validate protocol-vs-adapter boundary before coding.
-2. Run sandbox auth and baseline create/read operations.
-3. Run deterministic update cycle and verify ID/stop/reference stability.
-4. Build/validate FAXP message body and signed envelope.
-5. Run local conformance/readiness baseline:
+1. Confirm implementer-independence qualification and capture it in the evidence bundle.
+2. Validate protocol-vs-adapter boundary before coding.
+3. Run sandbox auth and baseline create/read operations.
+4. Run deterministic update cycle and verify ID/stop/reference stability.
+5. Build/validate FAXP message body and signed envelope.
+6. Run local conformance/readiness baseline:
    - `.venv/bin/python tests/run_open_source_guardrails.py`
    - `.venv/bin/python tests/run_release_readiness.py`
    - `.venv/bin/python tests/run_conformance_suite.py`
-6. Produce anonymized evidence artifacts only.
-7. Populate and retain one evidence bundle using:
+7. Produce anonymized evidence artifacts only.
+8. Populate and retain one evidence bundle using:
    - `docs/builders/SECOND_IMPLEMENTER_EVIDENCE_BUNDLE_TEMPLATE.json`
 
 ## Required Evidence Artifacts
@@ -70,4 +85,5 @@ Do not include:
 2. Deterministic identifiers remain stable through update/readback checks.
 3. Public artifacts remain partner-safe and anonymized.
 4. Protocol scope remains unchanged (no out-of-scope expansion).
-5. Evidence is sufficient to support beta-promotion discussion.
+5. Independence qualification is documented and reviewable in the evidence bundle.
+6. Evidence is sufficient to support beta-promotion discussion.

--- a/docs/builders/SECOND_IMPLEMENTER_EVIDENCE_BUNDLE_TEMPLATE.json
+++ b/docs/builders/SECOND_IMPLEMENTER_EVIDENCE_BUNDLE_TEMPLATE.json
@@ -10,6 +10,15 @@
     "alias": "anonymous_implementer_a",
     "integrationType": "tms_adapter_sandbox"
   },
+  "independenceQualification": {
+    "isIndependentImplementer": true,
+    "separateImplementationOwner": true,
+    "separateRuntimeCredentials": true,
+    "realSandboxExecution": true,
+    "syntheticOnlyOrMockedFlow": false,
+    "evidenceReviewedByOwner": "truckingadvantage",
+    "reviewedAtUtc": "2026-03-16T00:30:00Z"
+  },
   "scopeValidation": {
     "bookingPlaneOnly": true,
     "dispatchOrSettlementOutOfScope": true,
@@ -37,6 +46,7 @@
   "notes": [
     "Replace sample timestamps with the actual sandbox run window.",
     "Set result to PASS/PARTIAL/BLOCKED for each completed implementer run.",
+    "Never mark PASS for synthetic-only or mocked integration flows.",
     "Keep all public artifacts vendor-neutral and non-attributable."
   ]
 }

--- a/tests/run_second_implementer_evidence_bundle_template.py
+++ b/tests/run_second_implementer_evidence_bundle_template.py
@@ -55,6 +55,7 @@ def main() -> int:
         "result",
         "evaluationWindow",
         "implementer",
+        "independenceQualification",
         "scopeValidation",
         "executionChecks",
         "publicSafety",
@@ -85,6 +86,42 @@ def main() -> int:
     _assert(alias, "implementer.alias must be non-empty.")
     _assert(integration_type, "implementer.integrationType must be non-empty.")
     _assert_no_local_path(alias, "implementer.alias")
+
+    independence = payload.get("independenceQualification") or {}
+    _assert(isinstance(independence, dict), "independenceQualification must be an object.")
+    for key in [
+        "isIndependentImplementer",
+        "separateImplementationOwner",
+        "separateRuntimeCredentials",
+        "realSandboxExecution",
+        "syntheticOnlyOrMockedFlow",
+    ]:
+        _assert(isinstance(independence.get(key), bool), f"independenceQualification.{key} must be boolean.")
+    _assert(
+        independence.get("isIndependentImplementer") is True,
+        "independenceQualification.isIndependentImplementer must be true in template baseline.",
+    )
+    _assert(
+        independence.get("separateImplementationOwner") is True,
+        "independenceQualification.separateImplementationOwner must be true in template baseline.",
+    )
+    _assert(
+        independence.get("separateRuntimeCredentials") is True,
+        "independenceQualification.separateRuntimeCredentials must be true in template baseline.",
+    )
+    _assert(
+        independence.get("realSandboxExecution") is True,
+        "independenceQualification.realSandboxExecution must be true in template baseline.",
+    )
+    _assert(
+        independence.get("syntheticOnlyOrMockedFlow") is False,
+        "independenceQualification.syntheticOnlyOrMockedFlow must be false in template baseline.",
+    )
+    reviewer = str(independence.get("evidenceReviewedByOwner") or "").strip()
+    _assert(reviewer, "independenceQualification.evidenceReviewedByOwner must be non-empty.")
+    _assert_no_local_path(reviewer, "independenceQualification.evidenceReviewedByOwner")
+    reviewed_at = str(independence.get("reviewedAtUtc") or "").strip()
+    _parse_iso8601(reviewed_at, "independenceQualification.reviewedAtUtc")
 
     scope_validation = payload.get("scopeValidation") or {}
     _assert(isinstance(scope_validation, dict), "scopeValidation must be an object.")


### PR DESCRIPTION
## Summary
- Tightens Workstream F so completion requires a real second independent implementer demo.
- Adds explicit no-synthetic/no-mock-only qualification language.
- Extends evidence bundle template with independence qualification fields.
- Enforces new fields with template validation tests.

## What changed
- Updated second implementer checklist with qualification and disqualification rules.
- Updated anonymized integration outcome template with independent implementer requirements.
- Updated adoption execution runbook to forbid closing criterion from synthetic/mock-only demos.
- Expanded second implementer evidence bundle template:
  - `independenceQualification.isIndependentImplementer`
  - `independenceQualification.separateImplementationOwner`
  - `independenceQualification.separateRuntimeCredentials`
  - `independenceQualification.realSandboxExecution`
  - `independenceQualification.syntheticOnlyOrMockedFlow`
  - `independenceQualification.evidenceReviewedByOwner`
  - `independenceQualification.reviewedAtUtc`
- Updated template validator to require and validate these fields.

## Validation
- `.venv/bin/python tests/run_second_implementer_evidence_bundle_template.py`
- `.venv/bin/python tests/run_adoption_execution_runbook.py`
- `.venv/bin/python tests/run_beta_promotion_criteria.py`
- `.venv/bin/python tests/run_open_source_guardrails.py`

## Scope
- Documentation and validation guardrails only.
- No protocol message schema expansion.
- No partner-specific identifiers added.
